### PR TITLE
Added an environment variable to override the default configuration. …

### DIFF
--- a/src/services/elasticsearch/index.js
+++ b/src/services/elasticsearch/index.js
@@ -9,7 +9,12 @@ let config = function () {
 }
 
 let ESClient = function () {
-    return new elasticsearch.Client(config());
+    let currentConfig = config()
+
+    if (process.env.REACT_APP_ELASTICSEARACH_HOST)
+        currentConfig.host = process.env.REACT_APP_ELASTICSEARACH_HOST;
+
+    return new elasticsearch.Client(currentConfig);
 }
 
 export const search = function (parameters) {


### PR DESCRIPTION
…Closes #46 

This PR will let @ronakmshah defines its elastic search server in a variable environment.

You can set your environment variable in your `~/.bash_profile` like:

```
export REACT_APP_ELASTICSEARACH_HOST=https://10.10.10.10:9020
```
