### PR TITLE
Introducing VSS Enterprise Dashboard

### DIFF
--- a/src/components/App/MainMenu.js
+++ b/src/components/App/MainMenu.js
@@ -84,6 +84,11 @@ class MainMenuView extends React.Component {
                         onTouchTap={() => {this.props.goTo("/dashboards/aarEnterprise?startTime=now-900h")}}
                         style={style.listItem}
                         />
+                    <ListItem
+                        primaryText="VSS"
+                        onTouchTap={() => {this.props.goTo("/dashboards/vssEnterprise?startTime=now-900h")}}
+                        style={style.listItem}
+                        />
                 </List>
 
                 <Subheader style={style.subHeader}>ENTERPRISES</Subheader>

--- a/src/configs/nuage/configurations/dashboards/vssEnterprise.json
+++ b/src/configs/nuage/configurations/dashboards/vssEnterprise.json
@@ -1,0 +1,12 @@
+{
+    "id": "vssEnterprise",
+    "author": "Ronak Shah",
+    "creationDate": "10/17/2016",
+    "title": "VSS Enterprise Dashboard",
+    "visualizations": [
+        { "id": "vss-ent-acldeny-time", "x": 6, "y": 0, "w": 6, "h": 22, "minW": 2, "minH": 12 },
+        { "id": "vss-top-domains-blocked-traffic", "x": 26, "y": 0, "w": 6, "h": 22, "minW": 2, "minH": 12},
+        { "id": "vss-top-sec-events", "x": 26, "y": 0, "w": 6, "h": 22, "minW": 2, "minH": 12}
+    ]
+}
+

--- a/src/configs/nuage/configurations/queries/vss-ent-acldeny-time.json
+++ b/src/configs/nuage/configurations/queries/vss-ent-acldeny-time.json
@@ -1,0 +1,72 @@
+{
+    "id":"vss-enterprise-acldeny-time",
+    "title":"ACL Deny vs Time",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_flow}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "2": {
+                    "filters":{
+                        "filters":{
+                            "Enterprise":{
+                                "query":{
+                                    "term":{
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "aggs": {
+                        "4": {
+                            "filters": {
+                                "filters": {
+                                    "ACLDENY": {
+                                        "query": {
+                                            "term": {
+                                                "type": "DENY"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "aggs": {
+                                "3": {
+                                    "date_histogram": {
+                                        "field": "timestamp",
+                                        "interval": "1h"
+                                    },
+                                    "aggs": {
+                                        "1": {
+                                            "sum": {
+                                                "field": "packets"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/configs/nuage/configurations/queries/vss-top-domains-blocked-traffic.json
+++ b/src/configs/nuage/configurations/queries/vss-top-domains-blocked-traffic.json
@@ -1,0 +1,75 @@
+{
+    "id":"vss-topdomains-blocked-traffic",
+    "title":"Top Domains with Blocked Traffic",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_flow}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "2": {
+                    "filters":{
+                        "filters":{
+                            "Enterprise":{
+                                "query":{
+                                    "term":{
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "aggs": {
+                        "4": {
+                            "filters": {
+                                "filters": {
+                                    "ACLDENY": {
+                                        "query": {
+                                            "term": {
+                                                "type": "DENY"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "aggs": {
+                                "3": {
+                                    "terms": {
+                                        "field": "nuage_metadata.domainName",
+                                        "size": 5,
+                                        "order": {
+                                            "1": "desc"
+                                        }
+                                    },
+                                    "aggs": {
+                                        "1": {
+                                            "sum": {
+                                                "field": "packets"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/configs/nuage/configurations/queries/vss-top-sec-events.json
+++ b/src/configs/nuage/configurations/queries/vss-top-sec-events.json
@@ -1,0 +1,65 @@
+{
+    "id":"vss-top-sec-events",
+    "title":"Top Security Events by Type",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_event}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "2": {
+                    "filters":{
+                        "filters":{
+                            "Enterprise":{
+                                "query":{
+                                    "term":{
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "aggs": {
+                        "1": {
+                            "sum": {
+                                "field": "value"
+                            }
+                        },
+                        "3": {
+                            "terms": {
+                                "field": "type",
+                                "size": 5,
+                                "order": {
+                                    "1": "desc"
+                                }
+                            },
+                            "aggs": {
+                                "1": {
+                                    "sum": {
+                                        "field": "value"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/configs/nuage/configurations/visualizations/vss-ent-acldeny-time.json
+++ b/src/configs/nuage/configurations/visualizations/vss-ent-acldeny-time.json
@@ -1,0 +1,12 @@
+{
+    "id": "vss-ent-acldeny-time",
+    "graph": "LineGraph",
+    "title": "VSS Enterprise ACL Deny vs Time",
+    "author": "Ronak Shah",
+    "creationDate": "10/17/2016",
+    "data": {
+        "xColumn": "key",
+        "yColumn": "1"
+    },
+    "query": "vss-ent-acldeny-time"
+}

--- a/src/configs/nuage/configurations/visualizations/vss-top-domains-blocked-traffic.json
+++ b/src/configs/nuage/configurations/visualizations/vss-top-domains-blocked-traffic.json
@@ -1,0 +1,13 @@
+{
+    "id": "vss-top-domains-blocked-traffic",
+    "graph": "BarGraph",
+    "title": "Top 5 Apps",
+    "author": "Ronak Shah",
+    "creationDate": "10/17/2016",
+    "data": {
+        "xColumn": "Count of ACL-Deny",
+        "yColumn": "key",
+        "orientation": "horizontal"
+    },
+    "query": "vss-top-domains-blocked-traffic"
+}

--- a/src/configs/nuage/configurations/visualizations/vss-top-sec-events.json
+++ b/src/configs/nuage/configurations/visualizations/vss-top-sec-events.json
@@ -1,0 +1,12 @@
+{
+    "id": "vss-top-sec-events",
+    "graph": "BarGraph",
+    "title": "Top Security Events",
+    "author": "Ronak Shah",
+    "creationDate": "10/17/2016",
+    "data": {
+        "xColumn": "key",
+        "yColumn": "Count of Events"
+    },
+    "query": "vss-top-sec-events"
+}


### PR DESCRIPTION
Added 3 queries, 3 visualizations to complete graphing requirement
for VSS-Enterprise Dashboard.

Note: Temporarily I have kept vss-top-sec-events as vertical bar chart
but as soon as the pie-chart component is ready, we need to make a change
there. Have verified that the response is coming properly for all 3 queries and
for first 2 (acl-deny over time and top-x-domains) the graph is showing correctly.
