### PR TITLE
Adding navigation to couple of dashboards

### DIFF
--- a/src/configs/nuage/configurations/visualizations/top20-talkers-enterprise.json
+++ b/src/configs/nuage/configurations/visualizations/top20-talkers-enterprise.json
@@ -13,5 +13,13 @@
             { "column": "1", "label": "Total MB" }
         ]
     },
+    "listeners": [
+    {
+        "redirect": "/dashboards/aarEnterpriseAppDetail",
+        "params": {
+            "app": "Application"
+        }
+    }],
+
     "query": "top20-talkers-enterprise-table"
 }

--- a/src/configs/nuage/configurations/visualizations/vss-top-domains-blocked-traffic.json
+++ b/src/configs/nuage/configurations/visualizations/vss-top-domains-blocked-traffic.json
@@ -21,5 +21,12 @@
             "right": 40
         }
     },
+    "listeners": [
+    {
+        "redirect": "/dashboards/vssDomainACL",
+        "params": {
+            "domainName": "domains"
+        }
+    }],
     "query": "vss-top-domains-blocked-traffic"
 }


### PR DESCRIPTION
1. From VSS enterprise dashboard when clicked on a top x domains
vis's bar, it will navigate to a corresponding domain's acl-analytics dashboard.

2. From AAR Enterprise app list, when clicked on a row of a table, it will
redirect to aar-app-detail with corresponding app as param.