### PR TITLE
Enabled templatable title at visualization level. Fixes #176

### DIFF
--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -20,6 +20,7 @@ import {
 } from "../../services/configurations/redux/actions";
 
 import { resizeVisualization } from "../../utils/resize"
+import { contextualize } from "../../utils/configurations"
 
 import { GraphManager } from "../Graphs/index";
 import { ServiceManager } from "../../services/servicemanager/index";
@@ -166,8 +167,7 @@ class VisualizationView extends React.Component {
     }
 
     renderVisualization() {
-        const { context,
-                configuration,
+        const { configuration,
                 queryConfiguration,
                 response
         } = this.props;
@@ -252,7 +252,17 @@ class VisualizationView extends React.Component {
     shouldShowTitleBar() {
         const { configuration } = this.props;
 
-        return configuration && configuration.get("title") && this.state.parameterizable;
+        return configuration && this.currentTitle && this.state.parameterizable;
+    }
+
+    currentTitle() {
+        const { configuration, context } = this.props;
+        const title = configuration.get("title");
+
+        if (!title)
+            return ;
+
+        return contextualize(title, context);
     }
 
     renderDescriptionIcon() {
@@ -271,14 +281,12 @@ class VisualizationView extends React.Component {
     }
 
     renderTitleBarIfNeeded() {
-        const { configuration } = this.props;
-
         if (!this.shouldShowTitleBar())
             return;
 
         return (
             <div style={style.cardTitle}>
-                {configuration.get("title")}
+                {this.currentTitle()}
                 <div className="pull-right">
                     {this.renderDescriptionIcon()}
                 </div>

--- a/src/utils/configurations.js
+++ b/src/utils/configurations.js
@@ -62,3 +62,7 @@ export const getUsedParameters = (configuration, context) => {
 
     return queryParams;
 }
+
+export const contextualize = (data, context) => {
+    return parse(data)(context);
+}


### PR DESCRIPTION
This PR allows to add `{{template}}` into our visualization configuration.

If the context does not allow the template to be resolved, it will return the `undefined` keyword.

Here is an example:
```
...
     "id": "vss-domain-acl-time",
    "graph": "LineGraph",
    "title": "ACL Hits vs Time for {{enterpriseName}}",
    "author": "Ronak Shah",
    "creationDate": "10/18/2016",
...
```
If enterpriseName is not currently in the context, it will return:
```
ACL Hits vs Time for undefined
```

This is an expected behaviour. Please set a default value if necessary using the exact same format as usual: `{{enterpriseName:unknown}}` for instance.