### PR TITLE
VSS Graphs Fixes

### DIFF
--- a/public/configurations/dashboards/vssDomainFlow.json
+++ b/public/configurations/dashboards/vssDomainFlow.json
@@ -4,8 +4,8 @@
     "creationDate": "11/02/2016",
     "title": "VSS Domain Flow Visualization",
     "visualizations": [
-        { "id": "vss-domain-flow", "x": 0, "y": 0, "w": 5, "h": 30, "minW": 2, "minH": 12},
-        { "id": "vss-domain-flow-table", "x": 5, "y": 0, "w": 5, "h": 30, "minW": 2 , "minH": 12}
+        { "id": "vss-domain-flow", "x": 0, "y": 0, "w": 5, "h": 25, "minW": 2, "minH": 12},
+        { "id": "vss-domain-flow-table", "x": 5, "y": 0, "w": 5, "h": 25, "minW": 2 , "minH": 12}
     ],
     "links": [
         {

--- a/public/configurations/queries/vss-domain-acl-dpg.json
+++ b/public/configurations/queries/vss-domain-acl-dpg.json
@@ -29,38 +29,53 @@
                             "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACL": {
-                                        "query": {
-                                            "term": {
-                                                "type": "{{actionType:DENY}}"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "dpg": {
-                                    "terms": {
-                                        "field": "nuage_metadata.destinationpolicygroups",
-                                        "size": 5,
-                                        "order": {
-                                            "SumOf": "desc"
+                                "4": {
+                                    "filters": {
+                                        "filters": {
+                                            "ACL": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "{{actionType:DENY}}"
+                                                    }
+                                                }
+                                            }
                                         }
                                     },
                                     "aggs": {
-                                        "SumOf": {
-                                            "sum": {
-                                                "field": "packets"
+                                        "dpg": {
+                                            "terms": {
+                                                "field": "nuage_metadata.destinationpolicygroups",
+                                                "size": 5,
+                                                "order": {
+                                                    "SumOf": "desc"
+                                                }
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/public/configurations/queries/vss-domain-acl-spg.json
+++ b/public/configurations/queries/vss-domain-acl-spg.json
@@ -29,38 +29,53 @@
                             "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACL": {
-                                        "query": {
-                                            "term": {
-                                                "type": "{{actionType:DENY}}"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "spg": {
-                                    "terms": {
-                                        "field": "nuage_metadata.sourcepolicygroups",
-                                        "size": 5,
-                                        "order": {
-                                            "SumOf": "desc"
+                                "4": {
+                                    "filters": {
+                                        "filters": {
+                                            "ACL": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "{{actionType:DENY}}"
+                                                    }
+                                                }
+                                            }
                                         }
                                     },
                                     "aggs": {
-                                        "SumOf": {
-                                            "sum": {
-                                                "field": "packets"
+                                        "spg": {
+                                            "terms": {
+                                                "field": "nuage_metadata.sourcepolicygroups",
+                                                "size": 5,
+                                                "order": {
+                                                    "SumOf": "desc"
+                                                }
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/public/configurations/queries/vss-domain-acl-time.json
+++ b/public/configurations/queries/vss-domain-acl-time.json
@@ -29,35 +29,50 @@
                             "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACL": {
-                                        "query": {
-                                            "term": {
-                                                "type": "{{actionType:DENY}}"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "timestamp": {
-                                    "date_histogram": {
-                                        "field": "timestamp",
-                                        "interval": "1h"
+                                "4": {
+                                    "filters": {
+                                        "filters": {
+                                            "ACL": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "{{actionType:DENY}}"
+                                                    }
+                                                }
+                                            }
+                                        }
                                     },
                                     "aggs": {
-                                        "SumOf": {
-                                            "sum": {
-                                                "field": "packets"
+                                        "timestamp": {
+                                            "date_histogram": {
+                                                "field": "timestamp",
+                                                "interval": "1h"
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/public/configurations/queries/vss-domain-events-by-pg.json
+++ b/public/configurations/queries/vss-domain-events-by-pg.json
@@ -29,25 +29,40 @@
                             "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "PG": {
-                            "terms": {
-                                "field": "nuage_metadata.sourcepolicygroups",
-                                "size": 5,
-                                "order": {
-                                    "Sum of Value": "desc"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             "aggs": {
-                                "Sum of Value": {
-                                    "sum": {
-                                        "field": "value"
+                                "PG": {
+                                    "terms": {
+                                        "field": "nuage_metadata.sourcepolicygroups",
+                                        "size": 5,
+                                        "order": {
+                                            "Sum of Value": "desc"
+                                        }
+                                    },
+                                    "aggs": {
+                                        "Sum of Value": {
+                                            "sum": {
+                                                "field": "value"
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/public/configurations/queries/vss-domain-events-by-type.json
+++ b/public/configurations/queries/vss-domain-events-by-type.json
@@ -29,25 +29,40 @@
                             "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "EventType": {
-                            "terms": {
-                                "field": "type",
-                                "size": 5,
-                                "order": {
-                                    "Sum of Value": "desc"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             "aggs": {
-                                "Sum of Value": {
-                                    "sum": {
-                                        "field": "value"
+                                "EventType": {
+                                    "terms": {
+                                        "field": "type",
+                                        "size": 5,
+                                        "order": {
+                                            "Sum of Value": "desc"
+                                        }
+                                    },
+                                    "aggs": {
+                                        "Sum of Value": {
+                                            "sum": {
+                                                "field": "value"
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/public/configurations/queries/vss-domain-flow.json
+++ b/public/configurations/queries/vss-domain-flow.json
@@ -26,42 +26,57 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "spg": {
-                            "terms": {
-                                "field": "nuage_metadata.sourcepolicygroups",
-                                "size": 5,
-                                "order": {
-                                    "SumOf": "desc"
-                                }   
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                            }
+                                        }
+                                    }
+                                }
                             },
                             "aggs": {
-                                "SumOf": {
-                                    "sum": {
-                                        "field": "packets"
-                                    }
-                                },
-                                "dpg": {
+                                "spg": {
                                     "terms": {
-                                        "field": "nuage_metadata.destinationpolicygroups",
+                                        "field": "nuage_metadata.sourcepolicygroups",
                                         "size": 5,
                                         "order": {
                                             "SumOf": "desc"
-                                        }
+                                        }   
                                     },
                                     "aggs": {
                                         "SumOf": {
                                             "sum": {
                                                 "field": "packets"
+                                            }
+                                        },
+                                        "dpg": {
+                                            "terms": {
+                                                "field": "nuage_metadata.destinationpolicygroups",
+                                                "size": 5,
+                                                "order": {
+                                                    "SumOf": "desc"
+                                                }
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/public/configurations/queries/vss-domain-traffic-icmp.json
+++ b/public/configurations/queries/vss-domain-traffic-icmp.json
@@ -26,51 +26,66 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACLALLOW": {
-                                        "query": {
-                                            "term": {
-                                                "type": "ALLOW"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "5": {
+                                "4": {
                                     "filters": {
                                         "filters": {
-                                            "Protocol": {
+                                            "ACLALLOW": {
                                                 "query": {
                                                     "term": {
-                                                        "protocol": "ICMP"
+                                                        "type": "ALLOW"
                                                     }
                                                 }
                                             }
                                         }
                                     },
                                     "aggs": {
-                                        "timestamp": {
-                                            "date_histogram": {
-                                                "field": "timestamp",
-                                                "interval": "1h"
+                                        "5": {
+                                            "filters": {
+                                                "filters": {
+                                                    "Protocol": {
+                                                        "query": {
+                                                            "term": {
+                                                                "protocol": "ICMP"
+                                                            }
+                                                        }
+                                                    }
+                                                }
                                             },
                                             "aggs": {
-                                                "SumOf": {
-                                                    "sum": {
-                                                        "field": "packets"
+                                                "timestamp": {
+                                                    "date_histogram": {
+                                                        "field": "timestamp",
+                                                        "interval": "1h"
+                                                    },
+                                                    "aggs": {
+                                                        "SumOf": {
+                                                            "sum": {
+                                                                "field": "packets"
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/public/configurations/queries/vss-domain-traffic-tcp-conn.json
+++ b/public/configurations/queries/vss-domain-traffic-tcp-conn.json
@@ -26,51 +26,66 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACLALLOW": {
-                                        "query": {
-                                            "term": {
-                                                "type": "ALLOW"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "5": {
+                                "4": {
                                     "filters": {
                                         "filters": {
-                                            "Protocol": {
+                                            "ACLALLOW": {
                                                 "query": {
                                                     "term": {
-                                                        "protocol": "TCP"
+                                                        "type": "ALLOW"
                                                     }
                                                 }
                                             }
                                         }
                                     },
                                     "aggs": {
-                                        "timestamp": {
-                                            "date_histogram": {
-                                                "field": "timestamp",
-                                                "interval": "1h"
+                                        "5": {
+                                            "filters": {
+                                                "filters": {
+                                                    "Protocol": {
+                                                        "query": {
+                                                            "term": {
+                                                                "protocol": "TCP"
+                                                            }
+                                                        }
+                                                    }
+                                                }
                                             },
                                             "aggs": {
-                                                "SumOf": {
-                                                    "sum": {
-                                                        "field": "packets"
+                                                "timestamp": {
+                                                    "date_histogram": {
+                                                        "field": "timestamp",
+                                                        "interval": "1h"
+                                                    },
+                                                    "aggs": {
+                                                        "SumOf": {
+                                                            "sum": {
+                                                                "field": "packets"
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/public/configurations/queries/vss-domain-traffic-tcp-synflood.json
+++ b/public/configurations/queries/vss-domain-traffic-tcp-synflood.json
@@ -26,38 +26,53 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "TYPE": {
-                                        "query": {
-                                            "term": {
-                                                "type": "TCP_SYN_FLOOD"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "timestamp": {
-                                    "date_histogram": {
-                                        "field": "timestamp",
-                                        "interval": "1h"
+                                "4": {
+                                    "filters": {
+                                        "filters": {
+                                            "TYPE": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "TCP_SYN_FLOOD"
+                                                    }
+                                                }
+                                            }
+                                        }
                                     },
                                     "aggs": {
-                                        "SumOf": {
-                                            "sum": {
-                                                "field": "value"
+                                        "timestamp": {
+                                            "date_histogram": {
+                                                "field": "timestamp",
+                                                "interval": "1h"
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "value"
+                                                    }
+                                                }
                                             }
                                         }
                                     }

--- a/public/configurations/queries/vss-domain-traffic-top-dpg.json
+++ b/public/configurations/queries/vss-domain-traffic-top-dpg.json
@@ -26,47 +26,62 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                      "5": {
-                        "filters": {
-                          "filters": {
-                            "Type": {
-                              "query": {
-                                "term": {
-                                  "type": "{{type:DENY}}"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "aggs": {
-                        "dpg": {
-                            "terms": {
-                                "field": "nuage_metadata.destinationpolicygroups",
-                                "size": 5,
-                                "order": {
-                                    "SumOf": "desc"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             "aggs": {
-                                "SumOf": {
-                                    "sum": {
-                                        "field": "packets"
+                                "5": {
+                                    "filters": {
+                                        "filters": {
+                                            "Type": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "{{type:DENY}}"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "aggs": {
+                                        "dpg": {
+                                            "terms": {
+                                                "field": "nuage_metadata.destinationpolicygroups",
+                                                "size": 5,
+                                                "order": {
+                                                    "SumOf": "desc"
+                                                }
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                        }
-                      }
                     }
                 }
             }

--- a/public/configurations/queries/vss-domain-traffic-top-spg.json
+++ b/public/configurations/queries/vss-domain-traffic-top-spg.json
@@ -26,47 +26,62 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                      "5": {
-                        "filters": {
-                          "filters": {
-                            "Type": {
-                              "query": {
-                                "term": {
-                                  "type": "{{type:DENY}}"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "aggs": {
-                        "spg": {
-                            "terms": {
-                                "field": "nuage_metadata.sourcepolicygroups",
-                                "size": 5,
-                                "order": {
-                                    "SumOf": "desc"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                            }
+                                        }
+                                    }
                                 }
                             },
                             "aggs": {
-                                "SumOf": {
-                                    "sum": {
-                                        "field": "packets"
+                                "5": {
+                                    "filters": {
+                                        "filters": {
+                                            "Type": {
+                                                "query": {
+                                                    "term": {
+                                                        "type": "{{type:DENY}}"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "aggs": {
+                                        "spg": {
+                                            "terms": {
+                                                "field": "nuage_metadata.sourcepolicygroups",
+                                                "size": 5,
+                                                "order": {
+                                                    "SumOf": "desc"
+                                                }
+                                            },
+                                            "aggs": {
+                                                "SumOf": {
+                                                    "sum": {
+                                                        "field": "packets"
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
                         }
-                        }
-                      }
                     }
                 }
             }

--- a/public/configurations/queries/vss-domain-traffic-udp.json
+++ b/public/configurations/queries/vss-domain-traffic-udp.json
@@ -26,51 +26,66 @@
                 "2": {
                     "filters":{
                         "filters":{
-                            "Domain":{
+                            "Enterprise":{
                                 "query":{
                                     "term":{
-                                        "nuage_metadata.domainName":"{{domainName:chord_domain}}"
+                                        "nuage_metadata.enterpriseName":"{{EnterpriseName:chord_enterprise}}"
                                     }
                                 }
                             }
                         }
                     },
                     "aggs": {
-                        "4": {
-                            "filters": {
-                                "filters": {
-                                    "ACLALLOW": {
-                                        "query": {
-                                            "term": {
-                                                "type": "ALLOW"
+                        "3": {
+                            "filters":{
+                                "filters":{
+                                    "Domain":{
+                                        "query":{
+                                            "term":{
+                                                "nuage_metadata.domainName":"{{domainName:chord_domain}}"
                                             }
                                         }
                                     }
                                 }
                             },
                             "aggs": {
-                                "5": {
+                                "4": {
                                     "filters": {
                                         "filters": {
-                                            "Protocol": {
+                                            "ACLALLOW": {
                                                 "query": {
                                                     "term": {
-                                                        "protocol": "UDP"
+                                                        "type": "ALLOW"
                                                     }
                                                 }
                                             }
                                         }
                                     },
                                     "aggs": {
-                                        "timestamp": {
-                                            "date_histogram": {
-                                                "field": "timestamp",
-                                                "interval": "1h"
+                                        "5": {
+                                            "filters": {
+                                                "filters": {
+                                                    "Protocol": {
+                                                        "query": {
+                                                            "term": {
+                                                                "protocol": "UDP"
+                                                            }
+                                                        }
+                                                    }
+                                                }
                                             },
                                             "aggs": {
-                                                "SumOf": {
-                                                    "sum": {
-                                                        "field": "packets"
+                                                "timestamp": {
+                                                    "date_histogram": {
+                                                        "field": "timestamp",
+                                                        "interval": "1h"
+                                                    },
+                                                    "aggs": {
+                                                        "SumOf": {
+                                                            "sum": {
+                                                                "field": "packets"
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }

--- a/public/configurations/queries/vss-ent-acldeny-time.json
+++ b/public/configurations/queries/vss-ent-acldeny-time.json
@@ -55,7 +55,7 @@
                                         "interval": "1h"
                                     },
                                     "aggs": {
-                                        "1": {
+                                        "SumOf": {
                                             "sum": {
                                                 "field": "packets"
                                             }

--- a/public/configurations/visualizations/vss-domain-acl-dpg.json
+++ b/public/configurations/visualizations/vss-domain-acl-dpg.json
@@ -1,7 +1,7 @@
 {
     "id": "vss-domain-acl-dpg",
     "graph": "BarGraph",
-    "title": "ACL Hits by Destination Policy Groups",
+    "title": "ACL Hits by Destination Policy Groups - {{actionType:DENY}}",
     "author": "Ronak Shah",
     "creationDate": "10/18/2016",
     "data": {
@@ -11,11 +11,14 @@
              "#fec26a"
          ],
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 80,
-            "right": 40
-        }
+            "right": 20
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-acl-dpg"
 }

--- a/public/configurations/visualizations/vss-domain-acl-spg.json
+++ b/public/configurations/visualizations/vss-domain-acl-spg.json
@@ -1,7 +1,7 @@
 {
     "id": "vss-domain-acl-spg",
     "graph": "BarGraph",
-    "title": "ACL Hits by Source Policy Group",
+    "title": "ACL Hits by Source Policy Group - {{actionType:DENY}}",
     "author": "Ronak Shah",
     "creationDate": "10/18/2016",
     "data": {
@@ -9,11 +9,14 @@
         "yColumn": "spg",
         "orientation": "horizontal",
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 80,
-            "right": 40
-        }
+            "right": 20
+        },
+        "xTickGrid": true,
+        "yTickGrid": false,
+        "xTickFormat": ".2s"
     },
     "query": "vss-domain-acl-spg"
 }

--- a/public/configurations/visualizations/vss-domain-acl-time.json
+++ b/public/configurations/visualizations/vss-domain-acl-time.json
@@ -1,7 +1,7 @@
 {
     "id": "vss-domain-acl-time",
     "graph": "LineGraph",
-    "title": "ACL Hits vs Time",
+    "title": "ACL Hits vs Time - {{actionType:DENY}}",
     "author": "Ronak Shah",
     "creationDate": "10/18/2016",
     "data": {
@@ -12,11 +12,14 @@
           "width": "2px"
         },
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 80,
-            "right": 40
-        }
+            "right": 20
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-acl-time"
 }

--- a/public/configurations/visualizations/vss-domain-events-by-pg.json
+++ b/public/configurations/visualizations/vss-domain-events-by-pg.json
@@ -8,11 +8,14 @@
         "xColumn": "PG",
         "yColumn": "Sum of Value",
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 80,
-            "right": 40
-        }
+            "right": 20
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-events-by-pg"
 }

--- a/public/configurations/visualizations/vss-domain-events-by-type.json
+++ b/public/configurations/visualizations/vss-domain-events-by-type.json
@@ -14,11 +14,15 @@
             "#7da3f7"
         ],
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 100,
-            "right": 40
-        }
+            "right": 20
+        },
+        "xTickGrid": true,
+        "yTickGrid": false,
+        "xTickFormat": ".2s",
+        "xTicks": 5
     },
     "query": "vss-domain-events-by-type"
 }

--- a/public/configurations/visualizations/vss-domain-flow-table.json
+++ b/public/configurations/visualizations/vss-domain-flow-table.json
@@ -1,7 +1,7 @@
 {
     "id": "vss-domain-flow-table",
     "graph": "Table",
-    "title": "PG to PG flow Detail",
+    "title": "{{spg:PG}} to {{dpg:PG}} flow Detail",
     "author": "Ronak Shah",
     "creationDate": "11/02/2016",
     "data": {

--- a/public/configurations/visualizations/vss-domain-traffic-icmp.json
+++ b/public/configurations/visualizations/vss-domain-traffic-icmp.json
@@ -12,11 +12,14 @@
             "width": "2px"
         },
         "margin": {
-            "top": 15,
-            "bottom": 20,
-            "left": 45,
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
             "right": 20
-        }
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-icmp"
 }

--- a/public/configurations/visualizations/vss-domain-traffic-tcp-conn.json
+++ b/public/configurations/visualizations/vss-domain-traffic-tcp-conn.json
@@ -12,11 +12,14 @@
             "width": "2px"
         },
         "margin": {
-            "top": 15,
-            "bottom": 20,
-            "left": 45,
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
             "right": 20
-        }
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-tcp-conn"
 }

--- a/public/configurations/visualizations/vss-domain-traffic-tcp-synflood.json
+++ b/public/configurations/visualizations/vss-domain-traffic-tcp-synflood.json
@@ -12,11 +12,14 @@
             "width": "2px"
         },
         "margin": {
-            "top": 15,
-            "bottom": 20,
-            "left": 60,
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
             "right": 20
-        }
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-tcp-synflood"
 }

--- a/public/configurations/visualizations/vss-domain-traffic-top-dpg.json
+++ b/public/configurations/visualizations/vss-domain-traffic-top-dpg.json
@@ -8,14 +8,17 @@
         "xColumn": "dpg",
         "yColumn": "SumOf",
         "margin": {
-            "top": 15,
-            "bottom": 20,
+            "top": 20,
+            "bottom": 40,
             "left": 80,
-            "right": 40
+            "right": 20
         },
         "colors": [
              "#fec26a"
-         ]
+         ],
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-top-dpg"
 }

--- a/public/configurations/visualizations/vss-domain-traffic-top-spg.json
+++ b/public/configurations/visualizations/vss-domain-traffic-top-spg.json
@@ -9,15 +9,14 @@
         "yColumn": "spg",
         "orientation": "horizontal",
         "margin": {
-            "top": 15,
-            "bottom": 20,
-            "left": 40,
-            "right": 40
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
+            "right": 20
         },
         "xTickGrid": true,
         "yTickGrid": false,
-        "xTickFormat": ".2s",
-        "xTicks": 5
+        "xTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-top-spg"
 }

--- a/public/configurations/visualizations/vss-domain-traffic-udp.json
+++ b/public/configurations/visualizations/vss-domain-traffic-udp.json
@@ -11,11 +11,14 @@
             "width": "2px"
         },
         "margin": {
-            "top": 15,
-            "bottom": 20,
-            "left": 45,
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
             "right": 20
-        }
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-domain-traffic-udp"
 }

--- a/public/configurations/visualizations/vss-ent-acldeny-time.json
+++ b/public/configurations/visualizations/vss-ent-acldeny-time.json
@@ -6,7 +6,7 @@
     "creationDate": "10/17/2016",
     "data": {
         "xColumn": "timestamp",
-        "yColumn": "1",
+        "yColumn": "SumOf",
         "stroke": {
             "color": "#f76159",
             "width": "2px"
@@ -16,7 +16,10 @@
             "bottom": 20,
             "left": 50,
             "right": 40
-        }
+        },
+        "xTickGrid": false,
+        "yTickGrid": true,
+        "yTickFormat": ".2s"
     },
     "query": "vss-ent-acldeny-time"
 }

--- a/public/configurations/visualizations/vss-top-domains-blocked-traffic.json
+++ b/public/configurations/visualizations/vss-top-domains-blocked-traffic.json
@@ -19,7 +19,11 @@
             "bottom": 20,
             "left": 70,
             "right": 40
-        }
+        },
+        "xTickGrid": true,
+        "yTickGrid": false,
+        "xTickFormat": ".2s",
+        "xTicks": 5
     },
     "listeners": [
     {

--- a/src/components/Dashboard/default.js
+++ b/src/components/Dashboard/default.js
@@ -4,13 +4,13 @@ export const defaultFilterOptions = {
         "default": "now-24h",
         "options": [
             {
-                "label": "24h",
-                "value": "now-24h",
-                "default": true
+                "label": "Last 15 min",
+                "value": "now-15m",
             },
             {
-                "label": "900h",
-                "value": "now-900h"
+                "label": "Last 24h",
+                "value": "now-24h",
+                "default": true
             },
             {
                 "label": "Last 7 days",
@@ -20,12 +20,12 @@ export const defaultFilterOptions = {
     },
     "Refresh interval": {
         "parameter": "refreshInterval",
-        "default": 6000,
+        "default": 3000,
         "disabled": true,
         "options": [
             {
-                "label": "60 seconds",
-                "value": 6000,
+                "label": "30 seconds",
+                "value": 3000,
                 "disabled": true
             }
         ]

--- a/src/components/Graphs/LineGraph/index.js
+++ b/src/components/Graphs/LineGraph/index.js
@@ -23,9 +23,13 @@ export default class LineGraph extends AbstractGraph {
           yTickGrid,
           yTickSizeInner,
           yTickSizeOuter,
+          yTickFormat,
+          yTicks,
           xTickGrid,
           xTickSizeInner,
           xTickSizeOuter,
+          xTickFormat,
+          xTicks,
           stroke,
         } = this.getConfiguredProperties();
 
@@ -44,9 +48,25 @@ export default class LineGraph extends AbstractGraph {
           .tickSizeInner(xTickGrid ? -innerHeight : xTickSizeInner)
           .tickSizeOuter(xTickSizeOuter);
 
+        if(xTickFormat){
+            xAxis.tickFormat(d3.format(xTickFormat));
+        }
+
+        if(xTicks){
+            xAxis.ticks(xTicks);
+        }
+
         const yAxis = d3.axisLeft(yScale)
           .tickSizeInner(yTickGrid ? -innerWidth : yTickSizeInner)
           .tickSizeOuter(yTickSizeOuter);
+
+        if(yTickFormat){
+            yAxis.tickFormat(d3.format(yTickFormat));
+        }
+
+        if(yTicks){
+            yAxis.ticks(yTicks);
+        }
 
         const line = d3.line()
           .x(function(d) { return xScale(d[xColumn]); })

--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -204,7 +204,7 @@ class VisualizationView extends React.Component {
                                 onTouchTapOverlay={() => { this.setState({showDescription: false}); }}
                                 />
         }
-        const timeout = configuration.get("refreshInterval") || 600000;
+        const timeout = configuration.get("refreshInterval") || 30000;
 
         return (
             <div>


### PR DESCRIPTION
1. Fixed Domain level queries to include enterprise filter as well.
This was a bug that I realized during unit-testing. Same domain name
could exist across Enterprise and thus the graphs could show incorrect data
unless its filter by enterprise as well.

2. Made default Refresh Interval to be 30 seconds

3. Added TickFormat and Ticks to the LineGraph.

4. Made appropriate margin changes and added TickFormats and Ticks
   to all VSS graphs

5. Made default refresh-interval to be 30 seconds