### PR TITLE
AAR Domain Dashboard fixes

### DIFF
--- a/public/configurations/dashboards/aarDomain.json
+++ b/public/configurations/dashboards/aarDomain.json
@@ -6,8 +6,8 @@
     "visualizations": [
         { "id": "top20-talkers-domain", "x": 0, "y": 0, "w": 10, "h": 15, "minW": 2, "minH": 12},
         { "id": "top5-app-vertical-bar-domain", "x": 0, "y": 15, "w": 5, "h": 15, "minW": 2, "minH": 12},
-        { "id": "aar-domain-top5-apmg", "x": 0, "y": 30, "w": 5, "h": 15, "minW": 2, "minH": 12},
+        { "id": "aar-domain-top5-apmg", "x": 0, "y": 30, "w": 3, "h": 15, "minW": 2, "minH": 12},
         { "id": "aar-domain-probe-path", "x": 5, "y": 15, "w": 5, "h": 15, "minW": 2, "minH": 12},
-        { "id": "aar-domain-probe-table", "x": 5, "y": 30, "w": 5, "h": 15, "minW": 2, "minH": 12}
+        { "id": "aar-domain-probe-table", "x": 3, "y": 30, "w": 7, "h": 15, "minW": 2, "minH": 12}
     ]
 }

--- a/public/configurations/queries/top20-talkers-domain-table.json
+++ b/public/configurations/queries/top20-talkers-domain-table.json
@@ -1,206 +1,166 @@
 {
-    "id":"top20-talkers-domain-table",
-    "title":"Top 20 talkers",
-    "service":"elasticsearch",
-    "query":{
-        "index":"{{index:nuage_dpi_flowstats}}",
-        "type":"{{type:nuage_doc_type}}",
-        "body":{
-                "size":0,
-                "query":{
-                    "bool":{
-                        "must":[
-                            {
-                                "range":{
-                                    "timestamp":{
-                                        "gte":"{{startTime:now-24h}}",
-                                        "lte":"{{endTime:now}}",
-                                        "format":"epoch_millis"
+    "id": "top20-talkers-domain-table",
+    "title": "Top 20 talkers",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_dpi_flowstats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": "{{startTime:now-24h}}",
+                                    "lte": "{{endTime:now}}",
+                                    "format": "epoch_millis"
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "2": {
+                    "filters": {
+                        "filters": {
+                            "Enterprise": {
+                                "query": {
+                                    "term": {
+                                        "EnterpriseName": "{{EnterpriseName:test_org}}"
                                     }
                                 }
                             }
-                        ]
-                    }
-                },
-                "aggs":{
-                    "2":{
-                        "filters":{
-                            "filters":{
-                                "Enterprise":{
-                                    "query":{
-                                        "term":{
-                                            "EnterpriseName":"{{EnterpriseName:test_org}}"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "aggs":{
-                            "3":{
-                                "filters":{
-                                    "filters":{
-                                        "Domain":{
-                                            "query":{
-                                                "term":{
-                                                    "DomainName":"{{domainName:Domain1}}"
-                                                }
+                        }
+                    },
+                    "aggs": {
+                        "3": {
+                            "filters": {
+                                "filters": {
+                                    "Domain": {
+                                        "query": {
+                                            "term": {
+                                                "DomainName": "{{domainName:Domain1}}"
                                             }
                                         }
                                     }
-                                },
-                                "aggs":{
-                                    "Application":{
-                                        "terms":{
-                                            "field":"Application",
-                                            "size":20,
-                                            "order":{
-                                                "1":"desc"
+                                }
+                            },
+                            "aggs": {
+                                "Application": {
+                                    "terms": {
+                                        "field": "Application",
+                                        "size": 20,
+                                        "order": {
+                                            "1": "desc"
+                                        }
+                                    },
+                                    "aggs": {
+                                        "1": {
+                                            "sum": {
+                                                "field": "TotalBytesCount"
                                             }
                                         },
-                                        "aggs":{
-                                            "1":{
-                                                "sum":{
-                                                    "field":"TotalMB"
+                                        "11": {
+                                            "sum": {
+                                                "field": "TotalPacketsCount"
+                                            }
+                                        },
+                                        "L7Classification": {
+                                            "terms": {
+                                                "field": "L7Classification",
+                                                "size": 20,
+                                                "order": {
+                                                    "1": "desc"
                                                 }
                                             },
-                                            "L7Classification":{
-                                                "terms":{
-                                                    "field":"L7Classification",
-                                                    "size":20,
-                                                    "order":{
-                                                        "1":"desc"
+                                            "aggs": {
+                                                "1": {
+                                                    "sum": {
+                                                        "field": "TotalBytesCount"
                                                     }
                                                 },
-                                                "aggs":{
-                                                    "1":{
-                                                        "sum":{
-                                                            "field":"TotalMB"
+                                                "11": {
+                                                    "sum": {
+                                                        "field": "TotalPacketsCount"
+                                                    }
+                                                },
+                                                "SrcVportName": {
+                                                    "terms": {
+                                                        "field": "SrcVportName",
+                                                        "size": 20,
+                                                        "order": {
+                                                            "1": "desc"
                                                         }
                                                     },
-                                                    "SrcVportName":{
-                                                        "terms":{
-                                                            "field":"SrcVportName",
-                                                            "size":20,
-                                                            "order":{
-                                                                "1":"desc"
+                                                    "aggs": {
+                                                        "1": {
+                                                            "sum": {
+                                                                "field": "TotalBytesCount"
                                                             }
                                                         },
-                                                        "aggs":{
-                                                            "1":{
-                                                                "sum":{
-                                                                    "field":"TotalMB"
+                                                        "11": {
+                                                            "sum": {
+                                                                "field": "TotalPacketsCount"
+                                                            }
+                                                        },
+                                                        "SourceNSG": {
+                                                            "terms": {
+                                                                "field": "SourceNSG",
+                                                                "size": 20,
+                                                                "order": {
+                                                                    "1": "desc"
                                                                 }
                                                             },
-                                                            "SourceNSG":{
-                                                                "terms":{
-                                                                    "field":"SourceNSG",
-                                                                    "size":20,
-                                                                    "order":{
-                                                                        "1":"desc"
+                                                            "aggs": {
+                                                                "1": {
+                                                                    "sum": {
+                                                                        "field": "TotalBytesCount"
                                                                     }
                                                                 },
-                                                                "aggs":{
-                                                                    "1":{
-                                                                        "sum":{
-                                                                            "field":"TotalMB"
+                                                                "11":{
+                                                                    "sum": {
+                                                                        "field": "TotalPacketsCount"
+                                                                    }
+                                                                },
+                                                                "DestinationNSG": {
+                                                                    "terms": {
+                                                                        "field": "DestinationNSG",
+                                                                        "size": 20,
+                                                                        "order": {
+                                                                            "1": "desc"
                                                                         }
                                                                     },
-                                                                    "SrcUplink":{
-                                                                        "terms":{
-                                                                            "field":"SrcUplink",
-                                                                            "size":20,
-                                                                            "order":{
-                                                                                "1":"desc"
+                                                                    "aggs": {
+                                                                        "1": {
+                                                                            "sum": {
+                                                                                "field": "TotalBytesCount"
                                                                             }
                                                                         },
-                                                                        "aggs":{
-                                                                            "1":{
-                                                                                "sum":{
-                                                                                    "field":"TotalMB"
+                                                                        "11": {
+                                                                            "sum": {
+                                                                                "field": "TotalPacketsCount"
+                                                                            }
+                                                                        },
+                                                                        "DestVportName": {
+                                                                            "terms": {
+                                                                                "field": "DestVportName",
+                                                                                "size": 20,
+                                                                                "order": {
+                                                                                    "1": "desc"
                                                                                 }
                                                                             },
-                                                                            "SrcUplinkRole":{
-                                                                                "terms":{
-                                                                                    "field":"SrcUplinkRole",
-                                                                                    "size":20,
-                                                                                    "order":{
-                                                                                        "1":"desc"
+                                                                            "aggs": {
+                                                                                "1": {
+                                                                                    "sum": {
+                                                                                        "field": "TotalBytesCount"
                                                                                     }
                                                                                 },
-                                                                                "aggs":{
-                                                                                    "1":{
-                                                                                        "sum":{
-                                                                                            "field":"TotalMB"
-                                                                                        }
-                                                                                    },
-                                                                                    "DstUplinkRole":{
-                                                                                        "terms":{
-                                                                                            "field":"DstUplinkRole",
-                                                                                            "size":20,
-                                                                                            "order":{
-                                                                                                "1":"desc"
-                                                                                            }
-                                                                                        },
-                                                                                        "aggs":{
-                                                                                            "1":{
-                                                                                                "sum":{
-                                                                                                    "field":"TotalMB"
-                                                                                                }
-                                                                                            },
-                                                                                            "DstUplink":{
-                                                                                                "terms":{
-                                                                                                    "field":"DstUplink",
-                                                                                                    "size":20,
-                                                                                                    "order":{
-                                                                                                        "1":"desc"
-                                                                                                    }
-                                                                                                },
-                                                                                                "aggs":{
-                                                                                                    "1":{
-                                                                                                        "sum":{
-                                                                                                            "field":"TotalMB"
-                                                                                                        }
-                                                                                                    },
-                                                                                                    "DestinationNSG":{
-                                                                                                        "terms":{
-                                                                                                            "field":"DestinationNSG",
-                                                                                                            "size":20,
-                                                                                                            "order":{
-                                                                                                                "1":"desc"
-                                                                                                            }
-                                                                                                        },
-                                                                                                        "aggs":{
-                                                                                                            "1":{
-                                                                                                                "sum":{
-                                                                                                                    "field":"TotalMB"
-                                                                                                                }
-                                                                                                            },
-                                                                                                            "DestVportName":{
-                                                                                                                "terms":{
-                                                                                                                    "field":"DestVportName",
-                                                                                                                    "size":20,
-                                                                                                                    "order":{
-                                                                                                                        "1":"desc"
-                                                                                                                    }
-                                                                                                                },
-                                                                                                                "aggs":{
-                                                                                                                    "1":{
-                                                                                                                        "sum":{
-                                                                                                                            "field":"TotalMB"
-                                                                                                                        }
-                                                                                                                    },
-                                                                                                                    "11":{
-                                                                                                                        "sum":{
-                                                                                                                            "field":"TotalPacketsCount"
-                                                                                                                        }
-                                                                                                                    }
-                                                                                                                }
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        }
+                                                                                "11": {
+                                                                                    "sum": {
+                                                                                        "field": "TotalPacketsCount"
                                                                                     }
                                                                                 }
                                                                             }
@@ -219,7 +179,7 @@
                         }
                     }
                 }
+            }
         }
     }
 }
-

--- a/public/configurations/queries/top5-app-vertical-bar-domain.json
+++ b/public/configurations/queries/top5-app-vertical-bar-domain.json
@@ -54,13 +54,13 @@
                                         "field":"Application",
                                         "size":5,
                                         "order":{
-                                            "Sum of MB":"desc"
+                                            "SumofBytes":"desc"
                                         }
                                     },
                                     "aggs":{
-                                        "Sum of MB":{
+                                        "SumofBytes":{
                                             "sum":{
-                                                "field":"TotalMB"
+                                                "field":"TotalBytesCount"
                                             }
                                         }
                                     }

--- a/public/configurations/visualizations/aar-domain-probe-table.json
+++ b/public/configurations/visualizations/aar-domain-probe-table.json
@@ -1,7 +1,7 @@
 {
     "id": "aar-domain-probe-table",
     "graph": "Table",
-    "title": "NSG to NSG Probe Detail",
+    "title": "{{snsg}} to {{dnsg}} Probe Detail",
     "author": "Ronak Shah",
     "creationDate": "11/02/2016",
     "data": {

--- a/public/configurations/visualizations/top20-talkers-domain.json
+++ b/public/configurations/visualizations/top20-talkers-domain.json
@@ -10,15 +10,25 @@
             { "column": "L7Classification", "label": "L7-Classification" },
             { "column": "SrcVportName", "label": "Source Vport-Name"},
             { "column": "SourceNSG", "label": "Source-NSG"},
-            { "column": "SrcUplink", "label": "Source Uplink"},
-            { "column": "SrcUplinkRole", "label": ""},
-            { "column": "DstUplinkRole", "label": ""},
-            { "column": "DstUplink", "label": ""},
             { "column": "DestinationNSG", "label": ""},
             { "column": "DestVportName", "label": ""},
-            { "column": "1", "label": "Total MB", "format": ",.2f" },
-            { "column": "11", "label": "Total Packets Count", "format": "," }
+            { "column": "1", "label": "Total Bytes", "format": ",.2s" },
+            { "column": "11", "label": "Total Packets", "format": ",.2s" }
         ]
     },
+    "listeners": [
+    {
+        "redirect": "/dashboards/aarNSGDetail",
+        "params": {
+            "snsg": "SourceNSG"
+        }
+    }],
+    "listeners": [
+    {
+        "redirect": "/dashboards/aarNSGDetail",
+        "params": {
+            "snsg": "DestinationNSG"
+        }
+    }],
     "query": "top20-talkers-domain-table"
 }

--- a/public/configurations/visualizations/top5-app-vertical-bar-domain.json
+++ b/public/configurations/visualizations/top5-app-vertical-bar-domain.json
@@ -5,8 +5,24 @@
     "author": "Ronak Shah",
     "creationDate": "10/14/2016",
     "data": {
+        "colors": [
+            "#7da3f7",
+            "#fec26a",
+            "#e78ac3",
+            "#f79e99",
+            "#b3d645"
+        ],
+        "margin": {
+            "top": 20,
+            "bottom": 40,
+            "left": 80,
+            "right": 20
+        },
+        "xLabel": "Application",
+        "yLabel": "Total Bytes",
+        "yTickFormat": ".2s",
         "xColumn": "Application",
-        "yColumn": "Sum of MB"
+        "yColumn": "SumofBytes"
     },
     "query": "top5-app-vertical-bar-domain"
 }


### PR DESCRIPTION
1. Removed srcuplink, srcuplinkrole, destuplink, destuplinkrole columns from top20-talkers-domain graph
2. fixed the top20-talkers-domain query to include both packets and bytes aggregation
2. Added x-label, y-label for top 5 apps
3. Display the Sourcensg and dest nsg names in the probe-detail table