### PR TITLE
Compute Resize with Title and Toolbar

### DIFF
--- a/src/utils/resize.js
+++ b/src/utils/resize.js
@@ -19,7 +19,9 @@ export const resizeVisualization = (gridItem) => {
 
     // Handle the case that the title bar is present.
     if (innerCard.length > 1) {
-        height -= innerCard[0].clientHeight;
+        
+        for (var i = 0; i < innerCard.length - 1; i++)
+            height -= innerCard[i].clientHeight;
     }
 
     return {


### PR DESCRIPTION
Previously, we were computed the height of the Card base on the title. 
As we have introduced the `filterOptions` that allows us to configure a filter toolbar, we need to take care of this case.

In a general, we should assume the graph will be on the latest inner node of the card.

Here is an integration without `filterOptions`:
![screen shot 2016-11-18 at 3 23 00 pm](https://cloud.githubusercontent.com/assets/1447243/20450268/fa2edf90-ada3-11e6-96fc-71ca28cf5daf.png)

Here is the version when we have `filterOptions`:
![screen shot 2016-11-18 at 3 22 44 pm](https://cloud.githubusercontent.com/assets/1447243/20450275/0b47989e-ada4-11e6-9928-71ebd3278e11.png)

This will fix an issue that @divyahc was running into this morning.

