### PR TITLE
Top 5 upload/download query correction

### DIFF
--- a/public/configurations/queries/aar-nsg-top5-talkers-download.json
+++ b/public/configurations/queries/aar-nsg-top5-talkers-download.json
@@ -41,18 +41,18 @@
                                 "field":"DstIp",
                                 "size":5,
                                 "order":{
-                                    "Packets":"desc"
+                                    "Bytes":"desc"
                                 }
                             },
                             "aggs":{
                                 "Packets":{
                                     "sum":{
-                                        "field":"EgressPackets"
+                                        "field":"IngressPackets"
                                     }
                                 },
                                 "Bytes":{
                                     "sum":{
-                                        "field":"EgressBytes"
+                                        "field":"IngressBytes"
                                     }
                                 },
                                 "DomainName":{
@@ -60,18 +60,18 @@
                                         "field":"Domain",
                                         "size":5,
                                         "order":{
-                                            "Packets":"desc"
+                                            "Bytes":"desc"
                                         }
                                     },
                                 "aggs":{
                                     "Packets":{
                                         "sum":{
-                                            "field":"EgressPackets"
+                                            "field":"IngressPackets"
                                         }
                                     },
                                     "Bytes":{
                                         "sum":{
-                                            "field":"EgressBytes"
+                                            "field":"IngressBytes"
                                         }
                                     }
                                 }

--- a/public/configurations/queries/aar-nsg-top5-talkers-upload.json
+++ b/public/configurations/queries/aar-nsg-top5-talkers-upload.json
@@ -41,7 +41,7 @@
                                 "field":"SrcIp",
                                 "size":5,
                                 "order":{
-                                    "Packets":"desc"
+                                    "Bytes":"desc"
                                 }
                             },
                             "aggs":{
@@ -60,7 +60,7 @@
                                         "field":"Domain",
                                         "size":5,
                                         "order":{
-                                            "Packets":"desc"
+                                            "Bytes":"desc"
                                         }
                                     },
                                 "aggs":{


### PR DESCRIPTION
1. Upload
Changing the aggregation based on bytes iso packets.

2. Download
a.Changing the aggregation based on bytes iso packets.
b.Current PPS/AAR feature behavior is that when the packet
comes from network to access it is being reported as an ingress from the
destination-NSG. So query need to be made accordingly.