### PR TITLE
Use context instead of query parameters

### DIFF
--- a/src/components/App/MainMenu.js
+++ b/src/components/App/MainMenu.js
@@ -9,8 +9,8 @@ import { List, ListItem } from "material-ui/List";
 import { ServiceManager } from "../../services/servicemanager/index";
 
 import {
-    Actions as ComponentActions,
-    ActionKeyStore as ComponentActionKeyStore
+    Actions as InterfaceActions,
+    ActionKeyStore as InterfaceActionKeyStore
 } from "./redux/actions";
 
 import {
@@ -252,9 +252,9 @@ const mapStateToProps = (state) => {
     };
 
     const props = {
-        context: state.interface.get(ComponentActionKeyStore.CONTEXT),
-        visualizationType: state.interface.get(ComponentActionKeyStore.VISUALIZATION_TYPE),
-        open: state.interface.get(ComponentActionKeyStore.MAIN_MENU_OPENED),
+        context: state.interface.get(InterfaceActionKeyStore.CONTEXT),
+        visualizationType: state.interface.get(InterfaceActionKeyStore.VISUALIZATION_TYPE),
+        open: state.interface.get(InterfaceActionKeyStore.MAIN_MENU_OPENED),
         isConnected: state.services.getIn([ServiceActionKeyStore.REQUESTS, ServiceManager.getRequestID(queryConfiguration), ServiceActionKeyStore.RESULTS]),
     };
 
@@ -273,15 +273,16 @@ const mapStateToProps = (state) => {
 
 const actionCreators = (dispatch) => ({
     onRequestChange: () => {
-      dispatch(ComponentActions.toggleMainMenu());
+      dispatch(InterfaceActions.toggleMainMenu());
     },
 
     setPageTitle: (aTitle) => {
-      dispatch(ComponentActions.updateTitle(aTitle));
+      dispatch(InterfaceActions.updateTitle(aTitle));
     },
 
-    goTo: function(link, filters) {
-        dispatch(push({pathname:link, query:filters}));
+    goTo: function(link, context) {
+        dispatch(InterfaceActions.updateContext(context))
+        dispatch(push({pathname:link}));
     },
 
     fetchEnterpriseIfNeeded: (enterpriseID) => {

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -18,6 +18,10 @@ import {
     ActionKeyStore as ConfigurationsActionKeyStore
 } from "../../services/configurations/redux/actions";
 
+import {
+    ActionKeyStore as InterfaceActionKeyStore
+} from "../App/redux/actions";
+
 import { contextualize } from "../../utils/configurations"
 
 import { defaultFilterOptions } from "./default.js"
@@ -60,13 +64,16 @@ export class DashboardView extends React.Component {
     }
 
     currentTitle() {
-        const { configuration, location } = this.props;
+        const {
+            configuration,
+            context
+        } = this.props;
         const title = configuration.get("title");
 
         if (!title)
             return ;
 
-        return contextualize(title, location.query);
+        return contextualize(title, context);
     }
 
     updateTitleIfNecessary(prevProps) {
@@ -98,7 +105,9 @@ export class DashboardView extends React.Component {
     }
 
     renderNavigationBarIfNeeded() {
-        const { configuration, location } = this.props;
+        const {
+            configuration
+        } = this.props;
 
         const links = configuration.get("links");
 
@@ -115,7 +124,7 @@ export class DashboardView extends React.Component {
                         return <li key={index}
                                    style={style.link}
                                    >
-                                    <Link to={{ pathname:targetURL, query:location.query }}>
+                                    <Link to={{ pathname:targetURL }}>
                                         {link.get("label")}
                                     </Link>
                                </li>;
@@ -128,8 +137,7 @@ export class DashboardView extends React.Component {
     render() {
         const { configuration,
                 error,
-                fetching,
-                location
+                fetching
         } = this.props;
 
         if (fetching) {
@@ -164,7 +172,7 @@ export class DashboardView extends React.Component {
                 <div>
                     {this.renderNavigationBarIfNeeded()}
 
-                    <FiltersToolBar filterOptions={fromJS(filterOptions)} context={location.query} />
+                    <FiltersToolBar filterOptions={fromJS(filterOptions)} />
 
                     <div style={style.gridContainer}>
                         <ResponsiveReactGridLayout
@@ -182,7 +190,6 @@ export class DashboardView extends React.Component {
                                     >
                                         <Visualization
                                             id={visualization.id}
-                                            context={location.query}
                                             registerResize={this.registerResize.bind(this)}
                                         />
                                     </div>
@@ -200,6 +207,8 @@ export class DashboardView extends React.Component {
 
 
 const mapStateToProps = (state, ownProps) => ({
+    context: state.interface.get(InterfaceActionKeyStore.CONTEXT),
+
     configuration: state.configurations.getIn([
         ConfigurationsActionKeyStore.DASHBOARDS,
         ownProps.params.id,

--- a/src/components/FiltersToolBar/index.js
+++ b/src/components/FiltersToolBar/index.js
@@ -6,6 +6,11 @@ import { connect } from "react-redux";
 import DropDownMenu from 'material-ui/DropDownMenu';
 import MenuItem from 'material-ui/MenuItem';
 
+import {
+    Actions as InterfaceActions,
+    ActionKeyStore as InterfaceActionKeyStore
+} from "../App/redux/actions";
+
 import style from "./styles";
 
 
@@ -76,18 +81,18 @@ export class FiltersToolBarView extends React.Component {
 }
 
 FiltersToolBarView.propTypes = {
-    filterOptions: React.PropTypes.object,
-    context: React.PropTypes.object
+    filterOptions: React.PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => ({
-
+    context: state.interface.get(InterfaceActionKeyStore.CONTEXT)
 })
 
 const actionCreators = (dispatch) => ({
 
-    goTo: function(link, filters) {
-        dispatch(push({pathname:link, query:filters}));
+    goTo: function(link, context) {
+        dispatch(InterfaceActions.updateContext(context));
+        dispatch(push({pathname:link}));
     }
 
 });

--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -14,10 +14,16 @@ import {
     Actions as ServiceActions,
     ActionKeyStore as ServiceActionKeyStore
 } from "../../services/servicemanager/redux/actions";
+
 import {
     Actions as ConfigurationsActions,
     ActionKeyStore as ConfigurationsActionKeyStore
 } from "../../services/configurations/redux/actions";
+
+import {
+    Actions as InterfaceActions,
+    ActionKeyStore as InterfaceActionKeyStore,
+} from "../App/redux/actions";
 
 import { resizeVisualization } from "../../utils/resize"
 import { contextualize } from "../../utils/configurations"
@@ -300,13 +306,13 @@ class VisualizationView extends React.Component {
     }
 
     renderFiltersToolBar() {
-        const { configuration, context } = this.props;
+        const { configuration } = this.props;
 
         if (!configuration || !configuration.get("filterOptions"))
             return;
 
         return (
-            <FiltersToolBar filterOptions={configuration.get("filterOptions")} context={context} />
+            <FiltersToolBar filterOptions={configuration.get("filterOptions")} />
         )
     }
 
@@ -340,7 +346,7 @@ class VisualizationView extends React.Component {
 const mapStateToProps = (state, ownProps) => {
 
     const configurationID = ownProps.id || ownProps.params.id,
-          context         = ownProps.context || ownProps.location.query;
+          context         = state.interface.get(InterfaceActionKeyStore.CONTEXT);
 
     const props = {
         id: configurationID,
@@ -401,8 +407,9 @@ const actionCreators = (dispatch) => ({
         dispatch(Actions.updateTitle(aTitle));
     },
 
-    goTo: function(link, filters) {
-        dispatch(push({pathname:link, query:filters}));
+    goTo: function(link, context) {
+        dispatch(InterfaceActions.updateContext(context));
+        dispatch(push({pathname:link}));
     },
 
     fetchConfigurationIfNeeded: function(id) {


### PR DESCRIPTION
This PR will close #213 

Previously, we were using query parameters to update `context` located in `state.interface`.
With this PR:

1. Dashboard now uses context from the state instead of reading location.query
2. Context is now centralized and we do not pass it as a property into all the components (Visualizations and FiltersToolBar)
3. When we need to change from one dashboard to another, we first update the context, and then change the URI.

Main advantages:
- URL are now clean. Only the first URL will receive all the parameters and then it will be stored in the context.
- You can still override the context using a query parameter if you want to manually test the changes.