### PR TITLE
Always set interval

### DIFF
--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -201,7 +201,6 @@ class VisualizationView extends React.Component {
     renderVisualization() {
         const {
             configuration,
-            context,
             queryConfiguration,
             response
         } = this.props;
@@ -219,25 +218,14 @@ class VisualizationView extends React.Component {
             return this.renderCardWithInfo("No data to visualize", "bar-chart");
         }
 
-        const refreshInterval = context.refreshInterval,
-              timeout         = configuration.refreshInterval || refreshInterval,
-              enabled         = refreshInterval > 0;
-
         return (
-            <div>
-                <ReactInterval
-                    enabled={enabled}
-                    timeout={parseInt(timeout, 10)}
-                    callback={() => { this.initialize(this.props.id) }}
-                    />
-                <GraphComponent
-                  data={data}
-                  configuration={configuration}
-                  width={this.state.width}
-                  height={this.state.height}
-                  {...this.state.listeners}
-                />
-            </div>
+            <GraphComponent
+              data={data}
+              configuration={configuration}
+              width={this.state.width}
+              height={this.state.height}
+              {...this.state.listeners}
+            />
         )
     }
 
@@ -304,7 +292,8 @@ class VisualizationView extends React.Component {
 
     render() {
         const {
-            configuration
+            configuration,
+            context
         } = this.props;
 
         if (!this.state.parameterizable || !configuration)
@@ -324,10 +313,14 @@ class VisualizationView extends React.Component {
 
         let cardText = Object.assign({}, style.cardText, {
             width: this.state.width,
-            height: this.state.height}
-        );
+            height: this.state.height
+        });
 
         const configStyle = configuration.styles || {};
+
+        let refreshInterval = context.refreshInterval,
+            timeout         = parseInt(configuration.refreshInterval || refreshInterval, 10),
+            enabled         = refreshInterval > 0;
 
         return (
             <Card
@@ -340,6 +333,11 @@ class VisualizationView extends React.Component {
                 <CardText style={cardText}>
                     { this.renderVisualizationIfNeeded() }
                     {description}
+                    <ReactInterval
+                        enabled={enabled}
+                        timeout={timeout}
+                        callback={() => { this.initialize(this.props.id) }}
+                        />
                 </CardText>
             </Card>
         );


### PR DESCRIPTION
Previously, we were setting the component `ReactInterval` on a visualization only when we were able to render it.

When we have no data, or the elastic search is down, the visualization will present a nice error message but won't be able to reload if there is any data coming.

This PR moved the `ReactInterval` in the render method to force the refresh even when no data have been found in a recent call.