### PR TITLE
Hide BarChart legend by default

### DIFF
--- a/src/components/Graphs/BarGraph/default.config.js
+++ b/src/components/Graphs/BarGraph/default.config.js
@@ -2,5 +2,8 @@ export const properties = {
     orientation: "vertical",
     stroke: {
         width: "1px"
+    },
+    legend: {
+        show: false
     }
 }


### PR DESCRIPTION
By default, `BarChart` does no longer show the legend.

We also discussed the `LineChart` behavior, but I think it is up the to configuration to choose whether or not to display the legend.