### PR TITLE
Fix the aarEnterprise newly_discovered_applications to display

### DIFF
--- a/public/configurations/queries/aar-default-app-l7.json
+++ b/public/configurations/queries/aar-default-app-l7.json
@@ -1,0 +1,51 @@
+{
+    "id":"aar-default-app-l7",
+    "title":"Distinct L7 count in Default Application",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_dpi_flowstats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{    
+            "size": 0,
+            "aggs": {
+                "2": {
+                    "filters":{
+                        "filters":{
+                            "App":{
+                                "query":{
+                                    "term":{
+                                        "Application":"Default Application"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "aggs": {
+                        "timezones": {
+                            "filters": {
+                                "filters": {
+                                    "LastTimeinterval": {
+                                        "range": {
+                                            "timestamp": {
+                                                "gte": "{{startTime:now-24h}}",
+                                                "lte": "{{endTime:now}}",
+                                                "format": "epoch_millis"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "aggs": {
+                                "l7_count": {
+                                   "cardinality": {
+                                       "field": "L7Classification"
+                                   }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/visualizations/newly-discovered-applications.json
+++ b/public/configurations/visualizations/newly-discovered-applications.json
@@ -1,8 +1,9 @@
 {
     "id": "newly-discovered-applications",
-    "title": "Newly Discovered Applications",
-    "query": "newly-discovered-applications",
+    "title": "Newly Discovered Default Applications",
+    "query": "aar-default-app-l7",
     "graph": "SimpleTextGraph",
     "data": {
+        "targetedColumn": "value"
     }
 }


### PR DESCRIPTION
distinct count of L7 Classifications in Default Application