### PR TITLE
Fixes VSD-20187

### DIFF
--- a/public/configurations/queries/aar-nsg-app-from-nsg.json
+++ b/public/configurations/queries/aar-nsg-app-from-nsg.json
@@ -51,12 +51,12 @@
                             "aggs": {
                                 "SumofBytes": {
                                     "sum": {
-                                        "field": "TotalBytesCount"
+                                        "field": "IngressBytes"
                                     }
                                 },
                                 "SumofPackets": {
                                     "sum": {
-                                        "field": "TotalPacketsCount"
+                                        "field": "IngressPackets"
                                     }
                                 },
                                 "APMGroup": {
@@ -70,12 +70,12 @@
                                     "aggs": {
                                         "SumofBytes": {
                                             "sum": {
-                                                "field": "TotalBytesCount"
+                                                "field": "IngressBytes"
                                             }
                                         },
                                         "SumofPackets": {
                                             "sum": {
-                                                "field": "TotalPacketsCount"
+                                                "field": "IngressPackets"
                                             }
                                         },
                                         "Application": {
@@ -89,12 +89,12 @@
                                             "aggs": {
                                                 "SumofBytes": {
                                                     "sum": {
-                                                        "field": "TotalBytesCount"
+                                                        "field": "IngressBytes"
                                                     }
                                                 },
                                                 "SumofPackets": {
                                                     "sum": {
-                                                        "field": "TotalPacketsCount"
+                                                        "field": "IngressPackets"
                                                     }
                                                 },
                                                 "L7Classification": {
@@ -108,12 +108,12 @@
                                                     "aggs": {
                                                         "SumofBytes": {
                                                             "sum": {
-                                                                "field": "TotalBytesCount"
+                                                                "field": "IngressBytes"
                                                             }
                                                         },
                                                         "SumofPackets": {
                                                             "sum": {
-                                                                "field": "TotalPacketsCount"
+                                                                "field": "IngressPackets"
                                                             }
                                                         },
                                                         "SrcVportName": {
@@ -127,17 +127,17 @@
                                                             "aggs": {
                                                                 "SumofBytes": {
                                                                     "sum": {
-                                                                        "field": "TotalBytesCount"
+                                                                        "field": "IngressBytes"
                                                                     }
                                                                 },
                                                                 "SumofPackets": {
                                                                     "sum": {
-                                                                        "field": "TotalPacketsCount"
+                                                                        "field": "IngressPackets"
                                                                     }
                                                                 },
-                                                                "SrcUplink": {
+                                                                "DestinationNSG": {
                                                                     "terms": {
-                                                                        "field": "SrcUplink",
+                                                                        "field": "DestinationNSG",
                                                                         "size": 5,
                                                                         "order": {
                                                                             "SumofBytes": "desc"
@@ -146,54 +146,12 @@
                                                                     "aggs": {
                                                                         "SumofBytes": {
                                                                             "sum": {
-                                                                                "field": "TotalBytesCount"
+                                                                                "field": "IngressBytes"
                                                                             }
                                                                         },
                                                                         "SumofPackets": {
                                                                             "sum": {
-                                                                                "field": "TotalPacketsCount"
-                                                                            }
-                                                                        },
-                                                                        "SrcUplinkRole": {
-                                                                            "terms": {
-                                                                                "field": "SrcUplinkRole",
-                                                                                "size": 5,
-                                                                                "order": {
-                                                                                    "SumofBytes": "desc"
-                                                                                }
-                                                                            },
-                                                                            "aggs": {
-                                                                                "SumofBytes": {
-                                                                                    "sum": {
-                                                                                        "field": "TotalBytesCount"
-                                                                                    }
-                                                                                },
-                                                                                "SumofPackets": {
-                                                                                    "sum": {
-                                                                                        "field": "TotalPacketsCount"
-                                                                                    }
-                                                                                },
-                                                                                "DestinationNSG": {
-                                                                                    "terms": {
-                                                                                        "field": "DestinationNSG",
-                                                                                        "size": 5,
-                                                                                        "order": {
-                                                                                            "SumofBytes": "desc"
-                                                                                        }
-                                                                                    },
-                                                                                    "aggs": {
-                                                                                        "SumofBytes": {
-                                                                                            "sum": {
-                                                                                                "field": "TotalBytesCount"
-                                                                                            }
-                                                                                        },
-                                                                                        "SumofPackets": {
-                                                                                            "sum": {
-                                                                                                "field": "TotalPacketsCount"
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                }
+                                                                                "field": "IngressPackets"
                                                                             }
                                                                         }
                                                                     }
@@ -214,3 +172,4 @@
         }
     }
 }
+

--- a/public/configurations/queries/aar-nsg-app-to-nsg.json
+++ b/public/configurations/queries/aar-nsg-app-to-nsg.json
@@ -19,7 +19,10 @@
                                 }
                             }
                         }
-                    ]
+                    ],
+                    "must_not": {
+                        "term" : { "EgressBytes" : 0 }
+                    }
                 }
             },
             "aggs":{
@@ -51,12 +54,12 @@
                             "aggs": {
                                 "SumofBytes": {
                                     "sum": {
-                                        "field": "TotalBytesCount"
+                                        "field": "EgressBytes"
                                     }
                                 },
                                 "SumofPackets": {
                                     "sum": {
-                                        "field": "TotalPacketsCount"
+                                        "field": "EgressPackets"
                                     }
                                 },
                                 "APMGroup": {
@@ -70,12 +73,12 @@
                                     "aggs": {
                                         "SumofBytes": {
                                             "sum": {
-                                                "field": "TotalBytesCount"
+                                                "field": "EgressBytes"
                                             }
                                         },
                                         "SumofPackets": {
                                             "sum": {
-                                                "field": "TotalPacketsCount"
+                                                "field": "EgressPackets"
                                             }
                                         },
                                         "Application": {
@@ -89,12 +92,12 @@
                                             "aggs": {
                                                 "SumofBytes": {
                                                     "sum": {
-                                                        "field": "TotalBytesCount"
+                                                        "field": "EgressBytes"
                                                     }
                                                 },
                                                 "SumofPackets": {
                                                     "sum": {
-                                                        "field": "TotalPacketsCount"
+                                                        "field": "EgressPackets"
                                                     }
                                                 },
                                                 "L7Classification": {
@@ -108,12 +111,12 @@
                                                     "aggs": {
                                                         "SumofBytes": {
                                                             "sum": {
-                                                                "field": "TotalBytesCount"
+                                                                "field": "EgressBytes"
                                                             }
                                                         },
                                                         "SumofPackets": {
                                                             "sum": {
-                                                                "field": "TotalPacketsCount"
+                                                                "field": "EgressPackets"
                                                             }
                                                         },
                                                         "DestVportName": {
@@ -127,75 +130,12 @@
                                                             "aggs": {
                                                                 "SumofBytes": {
                                                                     "sum": {
-                                                                        "field": "TotalBytesCount"
+                                                                        "field": "EgressBytes"
                                                                     }
                                                                 },
                                                                 "SumofPackets": {
                                                                     "sum": {
-                                                                        "field": "TotalPacketsCount"
-                                                                    }
-                                                                },
-                                                                "DstUplink": {
-                                                                    "terms": {
-                                                                        "field": "DstUplink",
-                                                                        "size": 5,
-                                                                        "order": {
-                                                                            "SumofBytes": "desc"
-                                                                        }
-                                                                    },
-                                                                    "aggs": {
-                                                                        "SumofBytes": {
-                                                                            "sum": {
-                                                                                "field": "TotalBytesCount"
-                                                                            }
-                                                                        },
-                                                                        "SumofPackets": {
-                                                                            "sum": {
-                                                                                "field": "TotalPacketsCount"
-                                                                            }
-                                                                        },
-                                                                        "DstUplinkRole": {
-                                                                            "terms": {
-                                                                                "field": "DstUplinkRole",
-                                                                                "size": 5,
-                                                                                "order": {
-                                                                                    "SumofBytes": "desc"
-                                                                                }
-                                                                            },
-                                                                            "aggs": {
-                                                                                "SumofBytes": {
-                                                                                    "sum": {
-                                                                                        "field": "TotalBytesCount"
-                                                                                    }
-                                                                                },
-                                                                                "SumofPackets": {
-                                                                                    "sum": {
-                                                                                        "field": "TotalPacketsCount"
-                                                                                    }
-                                                                                },
-                                                                                "DestinationNSG": {
-                                                                                    "terms": {
-                                                                                        "field": "DestinationNSG",
-                                                                                        "size": 5,
-                                                                                        "order": {
-                                                                                            "SumofBytes": "desc"
-                                                                                        }
-                                                                                    },
-                                                                                    "aggs": {
-                                                                                        "SumofBytes": {
-                                                                                            "sum": {
-                                                                                                "field": "TotalBytesCount"
-                                                                                            }
-                                                                                        },
-                                                                                        "SumofPackets": {
-                                                                                            "sum": {
-                                                                                                "field": "TotalPacketsCount"
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        }
+                                                                        "field": "EgressPackets"
                                                                     }
                                                                 }
                                                             }

--- a/public/configurations/visualizations/aar-nsg-app-from-nsg.json
+++ b/public/configurations/visualizations/aar-nsg-app-from-nsg.json
@@ -11,11 +11,9 @@
             { "column": "Application", "label": "Application" },
             { "column": "L7Classification", "label": "L7 Classification" },
             { "column": "SrcVportName", "label": "Source Vport" },
-            { "column": "SrcUplink", "label": "Source Uplink" },
-            { "column": "SrcUplinkRole", "label": "Source Uplink Role" },
             { "column": "DestinationNSG", "label": "Destination NSG" },
-            { "column": "SumofPackets", "label": "Total Packets", "format": ",.2s"},
-            { "column": "SumofBytes", "label": "Total Bytes", "format": ",.2s" } 
+            { "column": "SumofPackets", "label": "Ingress Packets", "format": ",.2s"},
+            { "column": "SumofBytes", "label": "Ingress Bytes", "format": ",.2s" }
         ]
     },
     "query": "aar-nsg-app-from-nsg"

--- a/public/configurations/visualizations/aar-nsg-app-to-nsg.json
+++ b/public/configurations/visualizations/aar-nsg-app-to-nsg.json
@@ -2,7 +2,7 @@
     "id": "aar-nsg-app-to-nsg",
     "graph": "Table",
     "title": "Application - To NSG",
-    "description": "NSG level report of applications connected to remote NSGs sending traffic to local (this) NSG. Computation: Sum of ingress Bytes in descending order.",
+    "description": "NSG level report of applications connected to remote NSGs sending traffic to local (this) NSG. Computation: Sum of egress Bytes in descending order.",
     "author": "Ronak Shah",
     "creationDate": "11/07/2016",
     "data": {
@@ -11,11 +11,8 @@
             { "column": "Application", "label": "Application" },
             { "column": "L7Classification", "label": "L7 Classification" },
             { "column": "DestVportName", "label": "Destination Vport" },
-            { "column": "DstUplink", "label": "Destination Uplink" },
-            { "column": "DstUplinkRole", "label": "Destination Uplink Role" },
-            { "column": "DestinationNSG", "label": "Destination NSG" },
-            { "column": "SumofPackets", "label": "Total Packets", "format": ",.2s"},
-            { "column": "SumofBytes", "label": "Total Bytes", "format": ",.2s" } 
+            { "column": "SumofPackets", "label": "Egress Packets", "format": ",.2s"},
+            { "column": "SumofBytes", "label": "Egress Bytes", "format": ",.2s" }
         ]
     },
     "query": "aar-nsg-app-to-nsg"


### PR DESCRIPTION
Modify the aar-nsg-app-from and aar-nsg-app-to queries to show ingress bytes and egress bytes
instead of ingress + egress bytes