### PR TITLE
#344 Line Chart configuration option for zero baseline

### DIFF
--- a/public/configurations/visualizations/wifi-branch-ssid-linechart.json
+++ b/public/configurations/visualizations/wifi-branch-ssid-linechart.json
@@ -12,6 +12,7 @@
         "yLabel": "Total Usage",
         "yTicks": 5,
         "linesColumn": "Users",
+        "zeroStart": false,
         "tooltip": [
             { "column": "Users", "label": "user" },
             { "column": "SumOf", "label": "Usage(rx/tx bytes)"}

--- a/src/components/Graphs/LineGraph/default.config.js
+++ b/src/components/Graphs/LineGraph/default.config.js
@@ -17,4 +17,5 @@ export const properties = {
         theme.palette.yellowLightColor,
         theme.palette.yellowDarkColor,
     ],
+    zeroStart: false,
 }

--- a/src/components/Graphs/LineGraph/index.js
+++ b/src/components/Graphs/LineGraph/index.js
@@ -62,8 +62,10 @@ class LineGraph extends XYGraph {
           yTicks,
           yTickSizeInner,
           yTickSizeOuter,
-          brushEnabled
+          brushEnabled,
+          zeroStart
         } = this.getConfiguredProperties();
+
 
         const isVerticalLegend = legend.orientation === 'vertical';
         const xLabelFn         = (d) => d[xColumn];
@@ -102,10 +104,17 @@ class LineGraph extends XYGraph {
             }
         }
 
+        let yExtent = extent(data, yLabelFn)
+
+        if(zeroStart && yExtent[0] > 0) {
+          yExtent[0] = 0;
+        }
+
         const xScale = scaleTime()
           .domain(extent(data, xLabelFn));
+
         const yScale = scaleLinear()
-          .domain(extent(data, yLabelFn));
+          .domain(yExtent);
 
         xScale.range([0, availableWidth]);
         yScale.range([availableHeight, 0]);

--- a/src/components/Graphs/MultiLineGraph/default.config.js
+++ b/src/components/Graphs/MultiLineGraph/default.config.js
@@ -17,4 +17,5 @@ export const properties = {
         theme.palette.yellowLightColor,
         theme.palette.yellowDarkColor,
     ],
+    zeroStart: false,
 }

--- a/src/components/Graphs/MultiLineGraph/index.js
+++ b/src/components/Graphs/MultiLineGraph/index.js
@@ -58,7 +58,8 @@ class LineGraph extends XYGraph {
           yTicks,
           yTickSizeInner,
           yTickSizeOuter,
-          brushEnabled
+          brushEnabled,
+          zeroStart
         } = this.getConfiguredProperties();
 
         let finalYColumn = typeof yColumn === 'object' ? yColumn : [yColumn];
@@ -130,10 +131,17 @@ class LineGraph extends XYGraph {
             }
         }
 
+        let yExtent = extent(filterDatas, yLabelUnformattedFn)
+
+        if(zeroStart && yExtent[0] > 0) {
+          yExtent[0] = 0;
+        }
+
         const xScale = scaleTime()
             .domain(extent(data, xLabelFn));
+
         const yScale = scaleLinear()
-            .domain(extent(filterDatas, yLabelUnformattedFn));
+            .domain(yExtent);
 
 
         xScale.range([0, availableWidth]);


### PR DESCRIPTION
@ronakmshah 

Issue: Add Line Chart configuration option for zero baseline #344

Added a "config parameter" named as "zeroStart". Set it to true, if you want to start the y axis from zero.
Added the same feature to MultiLine Chart as well.