### PR TITLE
Reverting sniff options

### DIFF
--- a/src/configs/nuage/elasticsearch/index.js
+++ b/src/configs/nuage/elasticsearch/index.js
@@ -8,10 +8,7 @@ let config = function () {
     return {
         host: null,
         log: 'trace',
-        apiVersion: '2.2',
-        sniffOnStart: true,                                                     
-        sniffInterval: 60000,                                                   
-        sniffOnConnectionFault: true      
+        apiVersion: '2.2'   
     }
 }
 


### PR DESCRIPTION
In the current Nuage setup ES is front ended by proxy and in that case sniff is not behaving as intended. Post middleware implementation we should put it back.