### PR TITLE
Added SLA charts in the application performance dashboard

### DIFF
--- a/public/configurations/dashboards/aarApplicationPerformance.json
+++ b/public/configurations/dashboards/aarApplicationPerformance.json
@@ -25,7 +25,12 @@
         { "id": "vsd-from-nsgs-table",  "x": 0, "y": 0,  "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false},
         { "id": "vsd-to-nsgs-table",    "x": 6, "y": 0,  "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false},
         { "id": "aar-flow-sla-heatmap", "x": 0, "y": 15, "w": 12, "h": 15, "minW": 2, "minH": 12, "static": false},
-        { "id": "aar-nsg-sla-details",  "x": 0, "y": 30, "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false},
-        { "id": "aar-nsg-sla-flow-details", "x": 6, "y": 30, "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false}
+        { "id": "aar-flow-uplink-pairs", "x": 0, "y": 15, "w": 2, "h": 40, "minW": 2, "minH": 12, "static": false},
+        { "id": "aar-nsg-per-port-traffic-linechart", "x": 2, "y": 30, "w": 10, "h": 10, "minW": 2, "minH": 10, "static": false},
+        { "id": "aar-nsg-per-port-pktloss-linechart", "x": 2, "y": 40, "w": 10, "h": 10, "minW": 2, "minH": 10, "static": false},
+        { "id": "aar-nsg-per-port-delay-linechart", "x": 2, "y": 50, "w": 10, "h": 10, "minW": 2, "minH": 10, "static": false},
+        { "id": "aar-nsg-per-port-jitter-linechart", "x": 2, "y": 60, "w": 10, "h": 10, "minW": 2, "minH": 10, "static": false},
+        { "id": "aar-nsg-sla-details",  "x": 0, "y": 90, "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false},
+        { "id": "aar-nsg-sla-flow-details", "x": 6, "y": 105, "w": 6, "h": 15, "minW": 2, "minH": 12, "static": false}
     ]
 }

--- a/public/configurations/queries/aar-flow-sla-heatmap.json
+++ b/public/configurations/queries/aar-flow-sla-heatmap.json
@@ -56,16 +56,23 @@
                         "field": "timestamp",
                         "interval": "{{heatmapinterval:30s}}"
                     },
-                    "aggs": {
-                        "application": {
+                    "aggs":{
+                        "appGroup":{
                             "terms": {
-                                "field": "Application"
+                                "field": "APPGroup"
                             },
                             "aggs": {
-                                "slastatus": {
+                                "application": {
                                     "terms": {
-                                        "size": 1,
-                                        "field": "SlaStatus"
+                                        "field": "Application"
+                                    },
+                                    "aggs": {
+                                        "slastatus": {
+                                            "terms": {
+                                                "size": 1,
+                                                "field": "SlaStatus"
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/public/configurations/queries/aar-flow-uplink-pairs.json
+++ b/public/configurations/queries/aar-flow-uplink-pairs.json
@@ -1,0 +1,57 @@
+{
+    "id": "aar-flow-uplink-pairs",
+    "title": "TBD",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_dpi_probestats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": 0,
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte": "{{startTime:now-24h}}",
+                                    "lte": "{{endTime:now}}",
+                                    "format": "epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DestinationNSG": "{{dnsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "APPGroup": "{{appGroup}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "srcUplink": {
+                    "terms": {
+                        "field": "SrcUplink"
+                    },
+                    "aggs": {
+                        "dstUplink": {
+                            "terms": {
+                                "field": "DstUplink"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/public/configurations/queries/aar-nsg-per-port-delay-linechart.json
+++ b/public/configurations/queries/aar-nsg-per-port-delay-linechart.json
@@ -1,0 +1,68 @@
+{
+    "id":"aar-nsg-per-port-delay-linechart",
+    "title":"TBD",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_dpi_probestats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DestinationNSG": "{{dnsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "SrcUplink": "{{srcUplink}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DstUplink": "{{dstUplink}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "ts": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "{{interval:1h}}"
+                    },
+                    "aggs": {
+                        "Delay": {
+                            "avg": {
+                                "field": "AvgDelay"
+                            }
+                        },
+                        "Configured SLA Delay":{
+                            "avg":{
+                                "field":"ConfigAvgDelay"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/public/configurations/queries/aar-nsg-per-port-jitter-linechart.json
+++ b/public/configurations/queries/aar-nsg-per-port-jitter-linechart.json
@@ -1,0 +1,68 @@
+{
+    "id":"aar-nsg-per-port-jitter-linechart",
+    "title":"TBD",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_dpi_probestats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DestinationNSG": "{{dnsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "SrcUplink": "{{srcUplink}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DstUplink": "{{dstUplink}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "ts": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "{{interval:1h}}"
+                    },
+                    "aggs": {
+                        "Jitter": {
+                            "avg": {
+                                "field": "AvgJitter"
+                            }
+                        },
+                        "Configured SLA Jitter":{
+                            "avg":{
+                                "field":"ConfigAvgJitter"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/public/configurations/queries/aar-nsg-per-port-pktloss-linechart.json
+++ b/public/configurations/queries/aar-nsg-per-port-pktloss-linechart.json
@@ -1,0 +1,68 @@
+{
+    "id":"aar-nsg-per-port-pktloss-linechart",
+    "title":"TBD",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_dpi_probestats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DestinationNSG": "{{dnsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "SrcUplink": "{{srcUplink}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DstUplink": "{{dstUplink}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "ts": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "{{interval:1h}}"
+                    },
+                    "aggs": {
+                        "PacketLoss": {
+                            "avg": {
+                                "field": "AvgPktLoss"
+                            }
+                        },
+                        "Configured SLA PacketLoss":{
+                            "avg": {
+                                "field": "ConfigAvgPktLoss"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/public/configurations/queries/aar-nsg-per-port-traffic-linechart.json
+++ b/public/configurations/queries/aar-nsg-per-port-traffic-linechart.json
@@ -1,0 +1,67 @@
+{
+    "id":"aar-nsg-per-port-traffic-linechart",
+    "title":"TBD",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_dpi_flowstats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "size":0,
+            "query":{
+                "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{startTime:now-24h}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                 "EnterpriseName": "{{enterpriseName:test_org}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DestinationNSG": "{{dnsg}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "SrcUplink": "{{srcUplink}}"
+                            }
+                        },
+                        {
+                            "term": {
+                                "DstUplink": "{{dstUplink}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs": {
+                "ts": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "{{interval:1h}}"
+                    },
+                    "aggs": {
+                        "Traffic": {
+                            "avg": {
+                                "field": "IngressMB"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/visualizations/aar-flow-sla-heatmap.json
+++ b/public/configurations/visualizations/aar-flow-sla-heatmap.json
@@ -23,14 +23,17 @@
         "tooltip": [
             { "column": "date_histo", "label": "Timestamp", "timeFormat": "%b %d, %y %X"},
             { "column": "application", "label": "Application" },
-            { "column": "slastatus", "label": "Status" }
+            { "column": "slastatus", "label": "Status" },
+            { "column": "appGroup", "label": "AppGroup" }
         ]
    },
    "listeners": [
         {
             "params": {
                 "appName": "application",
-                "queryStartTime": "date_histo"
+                "queryStartTime": "date_histo",
+                "appGroupId": "appGroup",
+                "slastatus": "slastatus"
             },
             "dateParams": {
                 "reference": "nsgSlaDetails",

--- a/public/configurations/visualizations/aar-flow-uplink-pairs.json
+++ b/public/configurations/visualizations/aar-flow-uplink-pairs.json
@@ -1,0 +1,24 @@
+{
+    "id": "aar-flow-uplink-pairs",
+    "graph": "Table",
+    "title": "",
+    "description": "Shows all uplink pairs for the flow",
+    "author": "Bharat Mukheja",
+    "creationDate": "11/21/2017",
+    "query": "aar-flow-uplink-pairs",
+    "listeners": [{
+      "params": {
+          "srcUplink": "srcUplink",
+          "dstUplink": "dstUplink"
+      }
+    }],
+    "data": {
+        "searchBar": false,
+        "hidePagination":true,
+        "limit":20,
+        "columns": [
+            { "column": "srcUplink", "label": "Source"},
+            { "column": "dstUplink", "label": "Destination" }
+        ]
+    }
+}

--- a/public/configurations/visualizations/aar-nsg-per-port-delay-linechart.json
+++ b/public/configurations/visualizations/aar-nsg-per-port-delay-linechart.json
@@ -1,0 +1,36 @@
+{
+    "id": "aar-nsg-per-port-delay-linechart",
+    "graph": "MultiLineGraph",
+    "title": "SLA Delay",
+    "description": "",
+    "author": "Bharat Mukheja",
+    "creationDate": "11/17/2017",
+    "data": {
+        "dateHistogram": true,
+        "xColumn": "ts",
+        "yColumn": ["Delay","Configured SLA Delay"],
+        "yTickFormat": ".2s",
+        "xLabel": "Time",
+        "yLabel": "Delay",
+        "linesColumn":["Delay","Configured SLA Delay"],
+        "stroke": {
+          "color": "#f76159",
+          "width": "2px"
+        },
+        "colors": [
+            "#ff0000",
+            "#000000"
+            ],
+        "legend": {
+            "orientation": "horizontal",
+            "show": true,
+            "circleSize": 5,
+            "labelOffset": 5
+        },
+        "tooltip": [
+            { "column": "Delay","label":"Actual Delay" },
+            { "column": "Configured SLA Delay","label":"Configured SLA Delay" }
+        ]
+    },
+    "query": "aar-nsg-per-port-delay-linechart"
+}

--- a/public/configurations/visualizations/aar-nsg-per-port-jitter-linechart.json
+++ b/public/configurations/visualizations/aar-nsg-per-port-jitter-linechart.json
@@ -1,0 +1,36 @@
+{
+    "id": "aar-nsg-per-port-jitter-linechart",
+    "graph": "MultiLineGraph",
+    "title": "SLA Jitter",
+    "description": "",
+    "author": "Bharat Mukheja",
+    "creationDate": "11/17/2017",
+    "data": {
+        "dateHistogram": true,
+        "xColumn": "ts",
+        "yColumn": ["Jitter","Configured SLA Jitter"],
+        "yTickFormat": ".2s",
+        "xLabel": "Time",
+        "yLabel": "Jitter",
+        "linesColumn":["Jitter","Configured SLA Jitter"],
+        "stroke": {
+          "color": "#f76159",
+          "width": "2px"
+        },
+        "legend": {
+            "orientation": "horizontal",
+            "show": true,
+            "circleSize": 5,
+            "labelOffset": 5
+        },
+        "colors": [
+            "#ff0000",
+            "#000000"
+            ],
+        "tooltip": [
+            { "column": "Jitter","label":"Actual Jitter" },
+            { "column": "Configured SLA Jitter","label":"Configured SLA Jitter" }
+        ]
+    },
+    "query": "aar-nsg-per-port-jitter-linechart"
+}

--- a/public/configurations/visualizations/aar-nsg-per-port-pktloss-linechart.json
+++ b/public/configurations/visualizations/aar-nsg-per-port-pktloss-linechart.json
@@ -1,0 +1,36 @@
+{
+    "id": "aar-nsg-per-port-pktloss-linechart",
+    "graph": "MultiLineGraph",
+    "title": "SLA Packet Loss",
+    "description": "",
+    "author": "Bharat Mukheja",
+    "creationDate": "11/17/2017",
+    "data": {
+        "dateHistogram": true,
+        "xColumn": "ts",
+        "yColumn": ["PacketLoss","Configured SLA PacketLoss"],
+        "yTickFormat": ".2s",
+        "xLabel": "Time",
+        "yLabel": "Packet Loss",
+        "linesColumn": ["PacketLoss","Configured SLA PacketLoss"],
+        "stroke": {
+          "color": "#f76159",
+          "width": "2px"
+        },
+        "legend": {
+            "orientation": "horizontal",
+            "show": true,
+            "circleSize": 5,
+            "labelOffset": 5
+        },
+        "colors": [
+            "#ff0000",
+            "#000000"
+            ],
+        "tooltip": [
+            { "column": "PacketLoss","label":"Actual Packet Loss" },
+            { "column": "Configured SLA PacketLoss","label":"Configured SLA Packet Loss" }
+        ]
+    },
+    "query": "aar-nsg-per-port-pktloss-linechart"
+}

--- a/public/configurations/visualizations/aar-nsg-per-port-traffic-linechart.json
+++ b/public/configurations/visualizations/aar-nsg-per-port-traffic-linechart.json
@@ -1,0 +1,34 @@
+{
+    "id": "aar-nsg-per-port-traffic-linechart",
+    "graph": "MultiLineGraph",
+    "title": "Traffic",
+    "description": "",
+    "author": "Bharat Mukheja",
+    "creationDate": "11/17/2017",
+    "data": {
+        "dateHistogram": true,
+        "xColumn": "ts",
+        "yColumn": "Traffic",
+        "yTickFormat": ".2s",
+        "xLabel": "Time",
+        "yLabel": "Traffic",
+        "linesColumn": "Traffic",
+        "stroke": {
+          "color": "#f76159",
+          "width": "2px"
+        },
+        "legend": {
+            "orientation": "horizontal",
+            "show": true,
+            "circleSize": 5,
+            "labelOffset": 5
+        },
+        "colors": [
+            "#000000"
+            ],
+        "tooltip": [
+            { "column": "Traffic","label":"Upload Traffic" }
+        ]
+    },
+    "query": "aar-nsg-per-port-traffic-linechart"
+}

--- a/src/configs/nuage/scripts/pps-simulator/simulate_pps_stats.py
+++ b/src/configs/nuage/scripts/pps-simulator/simulate_pps_stats.py
@@ -527,9 +527,12 @@ class SimulateProbeStats(object):
                         probe_record["MonitorPayload"] = perf_mon["monitor_payload"]
                         probe_record["MonitorProbeInterval"] = perf_mon["probe_interval"]
                         probe_record["MonitorProbeNoOfPackets"] = perf_mon["probe_num_pkts"]
-                        probe_record["AvgDelay"] = avg_latency
-                        probe_record["AvgJitter"] = avg_jitter
-                        probe_record["AvgPktLoss"] = avg_pktloss
+                        probe_record["AvgDelay"] = float(avg_latency)
+                        probe_record["AvgJitter"] = float(avg_jitter)
+                        probe_record["AvgPktLoss"] = float(avg_pktloss)
+                        probe_record["ConfigAvgDelay"] = 200.0
+                        probe_record["ConfigAvgJitter"] = 50.0
+                        probe_record["ConfigAvgPktLoss"] = 50.0
                         probe_record["Domain"] = domains[domain]
                         probe_record["EnterpriseName"] = self.def_ent_name
                         probe_record["ControlSessionState"] = self.contro_states[0]
@@ -542,16 +545,16 @@ class SimulateProbeStats(object):
 
                         if firstTS and initPacket == 1:
                             probe_record["ControlSessionState"] = self.contro_states[2]
-                            probe_record["AvgDelay"] = "Null"
-                            probe_record["AvgJitter"] = "Null"
-                            probe_record["AvgPktLoss"] = "Null"
+                            del probe_record["AvgDelay"]
+                            del probe_record["AvgJitter"]
+                            del probe_record["AvgPktLoss"]
                             initPacket = 0
                         else:
                             if get_random_with_prob(control_down_prob):
                                 probe_record["ControlSessionState"] = self.contro_states[3]
-                                probe_record["AvgDelay"] = "Null"
-                                probe_record["AvgJitter"] = "Null"
-                                probe_record["AvgPktLoss"] = "Null"
+                                del probe_record["AvgDelay"]
+                                del probe_record["AvgJitter"]
+                                del probe_record["AvgPktLoss"]
 
                         json.dump(probe_record, probestats,
                                   default=json_serial)


### PR DESCRIPTION
Added sla charts


Removed App group id from the charts


Corrected value types in simulator


Removed filter options from the sla charts


Fixed sla's to average


Added dynamic field for srcUplink and dstUplink


Corrected variables usage


Added cardinality for source and destination uplinks


New table in application performance


Test uplink pairs


Merge pull request #512 from bmukheja/l2domain

Included domain Type support in aarDomain queries for L2 domain
Elasticsearch 5.x compatible query changes

Merge pull request #519 from nuagenetworks/es-5.x

Elasticsearch 5.x compatible query changes
temp change


Added horizontal line in SLA stats


Added highlight row and hide header & footer feature

Added visualization for Traffic in sla


Removed Enterprise name from probestats


Fixed click event listener and added highlighted row feature

Removed Search Bar from table


Added Config sla parameters in pps simulator


Merge remote-tracking branch 'upstream/feature/table-changes' into bug/heatmap_click_cell


Increasing the Limit to 100
Merge remote-tracking branch 'upstream/feature/table-changes' into bug/heatmap_click_cell


Added Appgroup in sla heatmap


Updated name of uplink pairs


Added Appgroup in sla heatmap


Updated legend and names in sla visalizations


Removed temp files


Removed unused files