### PR TITLE
Filter context override

### DIFF
--- a/public/configurations/dashboards/aarApplicationPerformance.json
+++ b/public/configurations/dashboards/aarApplicationPerformance.json
@@ -46,7 +46,7 @@
                         "interval": "1m",
                         "prevStartTime": "now-30m",
                         "unit": "m",
-                        "duration": 15
+                        "duration": "15"
                     }
                 }
             ]

--- a/public/configurations/dashboards/aarApplicationPerformance.json
+++ b/public/configurations/dashboards/aarApplicationPerformance.json
@@ -44,7 +44,9 @@
                     "default": true,
                     "forceOptions": {
                         "interval": "1m",
-                        "prevStartTime": "now-30m"
+                        "prevStartTime": "now-30m",
+                        "unit": "m",
+                        "duration": 15
                     }
                 }
             ]

--- a/public/configurations/visualizations/top20-talkers-domain.json
+++ b/public/configurations/visualizations/top20-talkers-domain.json
@@ -20,13 +20,6 @@
     {
         "redirect": "/dashboards/aarNSGDetail",
         "params": {
-            "snsg": "SourceNSG"
-        }
-    }],
-    "listeners": [
-    {
-        "redirect": "/dashboards/aarNSGDetail",
-        "params": {
             "snsg": "DestinationNSG"
         }
     }],

--- a/src/components/App/redux/actions.js
+++ b/src/components/App/redux/actions.js
@@ -3,6 +3,7 @@ export const ActionTypes = {
     ACTION_NAV_BAR_SET_TITLE: "ACTION_NAV_BAR_SET_TITLE",
     ACTION_NAV_BAR_SET_TITLE_ICON: "ACTION_NAV_BAR_SET_TITLE_ICON",
     ACTION_UPDATE_CONTEXT: "ACTION_UPDATE_CONTEXT",
+    ACTION_FILTER_CONTEXT: "ACTION_FILTER_CONTEXT",
     ACTION_UPDATE_VISUALIZATION_TYPE: "ACTION_UPDATE_VISUALIZATION_TYPE",
     ACTION_NAV_BAR_HAS_LINKS: "ACTION_NAV_BAR_HAS_LINKS",
     ACTION_UPDATE_HEADER_COLOR: "ACTION_UPDATE_HEADER_COLOR",
@@ -16,7 +17,8 @@ export const ActionKeyStore = {
     CONTEXT: "context",
     VISUALIZATION_TYPE: "visualizationType",
     HEADERCOLOR: "headerColor",
-    UPDATEPAGE: "updatePage"
+    UPDATEPAGE: "updatePage",
+    FILTER_CONTEXT: "filterContext"
 };
 
 
@@ -41,6 +43,12 @@ export const Actions = {
     updateContext: (aContext) => {
         return {
             type: ActionTypes.ACTION_UPDATE_CONTEXT,
+            context: aContext
+        }
+    },
+    filterContext: (aContext) => {
+        return {
+            type: ActionTypes.ACTION_FILTER_CONTEXT,
             context: aContext
         }
     },

--- a/src/components/App/redux/reducer.js
+++ b/src/components/App/redux/reducer.js
@@ -7,6 +7,7 @@ initialState = initialState.set(ActionKeyStore.MAIN_MENU_OPENED, false);
 initialState = initialState.set(ActionKeyStore.NAV_BAR_TITLE, "");
 initialState = initialState.set(ActionKeyStore.NAV_BAR_TITLE_ICON, false);
 initialState = initialState.set(ActionKeyStore.CONTEXT, {});
+initialState = initialState.set(ActionKeyStore.FILTER_CONTEXT, {});
 initialState = initialState.set(ActionKeyStore.HASLINKS, false);
 initialState = initialState.set(ActionKeyStore.HEADERCOLOR, Map());
 initialState = initialState.set(ActionKeyStore.UPDATEPAGE, "");
@@ -26,6 +27,11 @@ function setTitleIcon(state, aTitleIcon) {
 function updateContext(state, aContext) {
     let currentContext = state.get(ActionKeyStore.CONTEXT);
     return state.set(ActionKeyStore.CONTEXT,  Object.assign({}, currentContext, aContext));
+}
+
+function filterContext(state, aContext) {
+    let currentContext = state.get(ActionKeyStore.FILTER_CONTEXT);
+    return state.set(ActionKeyStore.FILTER_CONTEXT, Object.assign({}, currentContext, aContext));
 }
 
 function updateVisualizationType(state, aType) {
@@ -58,6 +64,9 @@ function interfaceReducer(state = initialState, action) {
 
         case ActionTypes.ACTION_UPDATE_CONTEXT:
             return updateContext(state, action.context);
+
+        case ActionTypes.ACTION_FILTER_CONTEXT:
+            return filterContext(state, action.context);
 
         case ActionTypes.ACTION_UPDATE_VISUALIZATION_TYPE:
             return updateVisualizationType(state, action.visualizationType);

--- a/src/components/Dashboard/default.js
+++ b/src/components/Dashboard/default.js
@@ -11,7 +11,7 @@ export const defaultFilterOptions = {
                     "interval": "1m",
                     "prevStartTime": "now-30m",
                     "unit": "m",
-                    "duration": 15
+                    "duration": "15"
                 }
             },
             {
@@ -21,19 +21,17 @@ export const defaultFilterOptions = {
                     "interval": "1h",
                     "prevStartTime": "now-48h",
                     "unit": "h",
-                    "duration": 24
+                    "duration": "24"
                 }
             },
             {
                 "label": "Last 7 days",
                 "value": "now-7d",
-                "unit": "d",
-                "interval": 7,
                 "forceOptions": {
                     "interval": "12h",
                     "prevStartTime": "now-14d",
                     "unit": "d",
-                    "duration": 7
+                    "duration": "7"
                 }
             }
         ]

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -107,7 +107,8 @@ export class DashboardView extends React.Component {
     renderNavigationBarIfNeeded() {
         const {
             configuration,
-            context
+            context,
+            filterContext
         } = this.props;
 
         const links = configuration.get("links");
@@ -116,6 +117,7 @@ export class DashboardView extends React.Component {
             return;
 
         const currentUrl = window.location.pathname;
+        let contextWithFilter = Object.assign({}, context, filterContext)
 
         return (
             <div style={style.navigationContainer}>
@@ -128,7 +130,7 @@ export class DashboardView extends React.Component {
                         return <li key={index}
                                    style={highlight}
                                    >
-                                    <Link to={{ pathname:targetURL, query: context}}
+                                    <Link to={{ pathname:targetURL, query: contextWithFilter}}
                                     style={style.noneTextDecoration}
                                     >
                                         {link.get("label")}
@@ -225,6 +227,8 @@ export class DashboardView extends React.Component {
 
 const mapStateToProps = (state, ownProps) => ({
     context: state.interface.get(InterfaceActionKeyStore.CONTEXT),
+
+    filterContext: state.interface.get(InterfaceActionKeyStore.FILTER_CONTEXT),
 
     configuration: state.configurations.getIn([
         ConfigurationsActionKeyStore.DASHBOARDS,

--- a/src/components/FiltersToolBar/index.js
+++ b/src/components/FiltersToolBar/index.js
@@ -91,7 +91,6 @@ export class FiltersToolBarView extends React.Component {
         };
 
         if(Object.keys(configContexts).length !== 0) {
-            updateContext(configContexts)
             this.props.goTo(window.location.pathname, Object.assign({}, context, configContexts))
         }
     }
@@ -137,14 +136,12 @@ export class FiltersToolBarView extends React.Component {
 
                                     {configOptions.options.map((option, index) => {
 
-                                        let queryParams = Object.assign({}, context, {
-                                            [paramName]: option.value
-                                        });
+                                        let queryParams = {};
 
                                         let forceOptions = option.forceOptions;
 
                                         if (forceOptions)
-                                            queryParams = Object.assign({}, queryParams, this.updateForceOptionContext(forceOptions, configOptions.append));
+                                            queryParams = Object.assign({}, {[paramName]: option.value}, this.updateForceOptionContext(forceOptions, configOptions.append));
 
                                         return (
                                             <MenuItem
@@ -153,7 +150,7 @@ export class FiltersToolBarView extends React.Component {
                                                 primaryText={option.label}
                                                 style={style.menuItem}
                                                 disabled={option.disabled}
-                                                onTouchTap={() => { this.props.goTo(window.location.pathname, queryParams);}}
+                                                onTouchTap={() => { this.props.saveFilterContext(queryParams); this.props.goTo(window.location.pathname, Object.assign({}, context, queryParams));}}
                                                 />
                                         )
                                     })}
@@ -184,6 +181,9 @@ const actionCreators = (dispatch) => ({
 
     updateContext: function(context) {
         dispatch(InterfaceActions.updateContext(context));
+    },
+    saveFilterContext: function(context) {
+        dispatch(InterfaceActions.filterContext(context));
     }
 
 });

--- a/src/components/FiltersToolBar/index.js
+++ b/src/components/FiltersToolBar/index.js
@@ -25,16 +25,20 @@ export class FiltersToolBarView extends React.Component {
     }
 
     updateForceOptionContext(forceOptions, append) {
-      let context = {};
+      const {
+          context
+      } = this.props;
+
+      let forceContext = {};
       let filteredID = append ? this.getFilteredVisualizationId() : '';
 
       for(let key in forceOptions) {
-        if(forceOptions.hasOwnProperty(key)) {
-          context[`${filteredID}${key}`] = forceOptions[key];
+        if(forceOptions.hasOwnProperty(key) && (!context[key] || context[key] !== forceOptions[key])) {
+            forceContext[`${filteredID}${key}`] = forceOptions[key];
         }
       }
-      console.log('forceOptions', context)
-      return context;
+
+      return forceContext;
     }
 
     componentDidMount() {
@@ -51,31 +55,45 @@ export class FiltersToolBarView extends React.Component {
         for(let name in filterOptions) {
             if (filterOptions.hasOwnProperty(name)) {
                 let configOptions = filterOptions[name],
-                    paramName = visualizationId && configOptions.append ? `${filteredID}${configOptions.parameter}` : configOptions.parameter,
-                    currentValue  = context[paramName];
+                    paramName     = visualizationId && configOptions.append ? `${filteredID}${configOptions.parameter}` : configOptions.parameter,
+                    currentValue  = context[paramName],
+                    defaultOption = []
 
-                if (!currentValue) {
-                    // Update context with default value if not found
-                    configContexts[paramName] = configOptions.default;
 
-                    if (configOptions.options) {
-                        let defaultOption = configOptions.options.filter((option) => {
-                            if(option.value === configOptions.default) {
-                                return true;
-                            }
-                            return false;
-                        });
+                if (configOptions.options) {
+                    let value = currentValue ? currentValue : configOptions.default;
+                    // check value present in config. If not, then set value from default option
+                    for(let i = 0; i < configOptions.options.length; i++) {
+                        let option = configOptions.options[i];
 
-                        if(defaultOption.length && defaultOption[0].forceOptions) {
-                            Object.assign(configContexts, this.updateForceOptionContext(defaultOption[0].forceOptions, configOptions.append));
+                        if(option.value === value) {
+                            defaultOption = []
+                            defaultOption.push(option)
+                            break;
+                        }
+
+                        if(option.default) {
+                            defaultOption.push(option)
+                        }
+                    }
+
+                    if(defaultOption.length) {
+                        if(currentValue !== defaultOption[0].value) {
+                            configContexts[paramName] = defaultOption[0].value
+                        }
+
+                        if(defaultOption[0].forceOptions) {
+                            configContexts = Object.assign({}, configContexts, this.updateForceOptionContext(defaultOption[0].forceOptions, configOptions.append));
                         }
                     }
                 }
             }
         };
 
-        if(Object.keys(configContexts).length !== 0)
-          updateContext(configContexts);
+        if(Object.keys(configContexts).length !== 0) {
+            updateContext(configContexts)
+            this.props.goTo(window.location.pathname, Object.assign({}, context, configContexts))
+        }
     }
 
 

--- a/src/components/NextPrevFilter/index.js
+++ b/src/components/NextPrevFilter/index.js
@@ -19,7 +19,7 @@ export class NextPrevFilter extends React.Component {
 
         this.state = {
             page: 1,
-            duration: 15,
+            duration: "15",
             unit: "m",
             filterOptions: {
                 "startTime": "startTime",
@@ -68,7 +68,7 @@ export class NextPrevFilter extends React.Component {
         } = props;
 
         if(context.duration) {
-            this.setState({duration: context.duration});
+            this.setState({duration: parseInt(context.duration)});
             this.setState({unit: context.unit});
         }
 

--- a/src/redux/middlewares.js
+++ b/src/redux/middlewares.js
@@ -1,20 +1,4 @@
-export const updateContextMiddleware = store => next => action => {
-
-    const result = next(action),
-          state  = store.getState();
-
-    if (action.type === "@@reduxReactRouter/routerDidChange" && state.router)
-    {
-        // Generate a specific action to update the context
-        const action = {
-            type: "ACTION_UPDATE_CONTEXT",
-            context: state.router.location.query
-        };
-        store.dispatch(action);
-    }
-
-    return result;
-}
+import { ActionKeyStore } from "../components/App/redux/actions"
 
 // TODO: We need to find a way to plug middlewares like this one.
 // as it is very specific to Nuage features (VSS or AAR)
@@ -40,29 +24,39 @@ export const updateVisualizationTypeMiddleware = store => next => action => {
     return result;
 }
 
-export const updateConfigurationMiddleware = store => next => action => {
+export const updateContextMiddleware = store => next => action => {
     const result = next(action),
           state  = store.getState();
 
-    if (action.type === "@@reduxReactRouter/routerDidChange" && state.router
-        && (state.router.location.pathname.indexOf('dashboards') !== -1 
-        || state.router.location.pathname.indexOf('visualizations') !== -1))
-    {
-        const id           = state.router.params.id,
-              previousPage = state.interface.get("updatePage");
+    if (action.type === "@@reduxReactRouter/routerDidChange" && state.router) {
+
+        let context = state.router.location.query
+
+        if((state.router.location.pathname.indexOf('dashboards') !== -1
+            || state.router.location.pathname.indexOf('visualizations') !== -1))
+        {
+            const id           = state.router.params.id,
+                previousPage = state.interface.get(ActionKeyStore.UPDATEPAGE);
 
 
-        if(!previousPage || previousPage !== id ) {
+            if(!previousPage || previousPage !== id ) {
+                store.dispatch({
+                        type: "ACTION_UPDATE_PAGE",
+                        id: id
+                });
 
-            store.dispatch({
-                    type: "ACTION_UPDATE_PAGE",
-                    id: id
-            });
+                store.dispatch({
+                        type: "RESET_CONFIGURATION",
+                });
+            }
+        }
 
-            store.dispatch({
-                    type: "RESET_CONFIGURATION",
-            });
-        }      
+        const action = {
+            type: "ACTION_UPDATE_CONTEXT",
+            context
+        };
+
+        store.dispatch(action);
     }
 
     return result;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -6,7 +6,7 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import thunkMiddleware from "redux-thunk";
 import createLogger from "redux-logger";
 import { reducer as formReducer } from 'redux-form';
-import { updateContextMiddleware, updateVisualizationTypeMiddleware, updateConfigurationMiddleware } from "./middlewares";
+import { updateContextMiddleware, updateVisualizationTypeMiddleware } from "./middlewares";
 
 import configurationsReducer from "../services/configurations/redux/reducer";
 import ESReducer from "../configs/nuage/elasticsearch/redux/reducer";
@@ -44,8 +44,7 @@ const createStoreWithRouterAndMiddleware = composeWithDevTools(
         thunkMiddleware,
         loggerMiddleware,
         updateContextMiddleware,
-        updateVisualizationTypeMiddleware,
-        updateConfigurationMiddleware
+        updateVisualizationTypeMiddleware
     )
 )(createStore);
 


### PR DESCRIPTION
@bmukheja @ronakmshah 

Switching the context to the default value has been implemented. Now they are updating fine, in case if the current value does not exist in the provided filter, like startTime from now-24h to now-15h in case of "aarApplicationPerformance" dashboard. Please review.