### PR TITLE
Add default data source

### DIFF
--- a/src/components/Graphs/LineGraph/index.js
+++ b/src/components/Graphs/LineGraph/index.js
@@ -245,8 +245,9 @@ class LineGraph extends XYGraph {
             defaultYvalue = defaultY
             let [startRange, endRange] = yScale.domain()
 
-            if(typeof defaultY === 'object' && defaultY.source && defaultY.column && this.props[defaultY.source]) {
-                horizontalLineData = this.props[defaultY.source][0] || {}
+            if(typeof defaultY === 'object' && defaultY.column) {
+                const dataSource = defaultY.source || 'data'
+                horizontalLineData = this.props[dataSource] ? this.props[dataSource][0] : {}
                 defaultYvalue = horizontalLineData[defaultY.column] || null
             }
 


### PR DESCRIPTION
@ronakmshah 
Set default database if the data source is not defined for horizontal line in line-chart. For example- 
`

        "defaultY": 
        {
            "source": "data2", // if data source is not defined here then it will consider data source from 
                                            deafult data.

            "column": "memory",
            "tooltip": [
                { "column": "memory", "label": "memory"},
                { "column": "cpu", "label": "cpu"}
            ]
        },

`