### PR TITLE
Fixed search issue for 0 value

### DIFF
--- a/src/components/SearchBar/AdvancedResultProcessing.js
+++ b/src/components/SearchBar/AdvancedResultProcessing.js
@@ -12,17 +12,17 @@ export default class AdvancedResultProcessing extends SimpleResultProcessing {
 
         const field = this.tryToGetFieldCategory(fieldOrLabel);
         const searchedValue = value.toLowerCase();
-        let originalValue = (row[field]) ? row[field].toString().toLowerCase() : "";
+        let originalValue = (row[field] || row[field] === 0) ? row[field].toString().toLowerCase() : ""
 
         if(this.columns) {
-
             let column = this.columns.find(function(d) {
                 return d.column && d.column === field;
             });
 
             if(column) {
-                const formattedValue = columnAccessor(column);
-                originalValue = (formattedValue(row, true)) ? formattedValue(row, true).toString().toLowerCase() : "";  
+                const formatter = columnAccessor(column)
+                const formattedValue = formatter(row, true)
+                originalValue = (formattedValue || formattedValue === 0) ? formattedValue.toString().toLowerCase() : "" 
             }
         }
 


### PR DESCRIPTION
@ronakmshah 

Fixed issue for searching a column with 0 value. Now `Packets != 0` or `Packets == 0` working fine.
Please have a look