### PR TITLE
Status as Colored Circle in Table Rows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -346,6 +346,24 @@ Display nice Pie or Donut graphs
   - **border** same as before
   - **fontColor** color of the header text
 
+  - **columns** (Array) - Array of columns display in the table. Example -
+
+  ```javascript
+  "columns":
+    [
+        { "column": "type", "label": " ", "colors" : {
+            "OTHER": "green",
+            "DENY": "red"
+            }
+        },
+        { "column": "sourceip", "label": "SIP" },
+        { "column": "subnetName", "label": "Subnet", "totalCharacters":    16, "tooltip" : {"column": "nuage_metadata.subnetName"} }
+    ]```
+
+In above example, if a value of the column show via colors then add colors property in object and mentioned all values as a key and color as a value in order to replace color from value. Note: Add label property with space to declare empty column in the table. E.g -
+
+![table-status-with-color](https://user-images.githubusercontent.com/26645756/37336742-4d9023fc-26d8-11e8-80c9-1c14100bf85b.png)
+
 
 ##### ChordGraph
 - **outerPadding** [TO COMPLETE]. Default is `30`

--- a/src/components/Graphs/Table/index.js
+++ b/src/components/Graphs/Table/index.js
@@ -218,13 +218,19 @@ class Table extends AbstractGraph {
                     highlighter = true
                 }
 
+                if (columns[i].colors) {
+                    columnData =  (
+                        <div style={{ background:  columns[i].colors[originalData] || '', width: "10px", height: "10px", borderRadius: "50%", marginLeft: "6px", marginRight: "6px" }}></div>
+                    )
+                }
                 data[columns[i].column] = columnData;
             });
 
             if(highlighter)
-               Object.keys(data).map( key => {
-                return data[key] = <div style={{background: highlightColor, height: style.row.height, padding: "10px 0"}}>{data[key]}</div>
-            })
+                Object.keys(data).map(key => {
+                    return data[key] = <div style={{ background: highlightColor || '', height: style.row.height, padding: "10px 0" }}>
+                        {data[key]}</div>
+                })
 
             return data
         })


### PR DESCRIPTION
@ronakmshah @bmukheja 

To configure colored circles, we have to add  "colors" property to the columns and define the colors for the possible values like below:

`
[
{ "column": "type", "label": " ", "colors" : {// columnValue => color
      "OTHER": "green", // columnValue => color
      "DENY": "red"   // columnValue => color
      }
}
]
`

Note: Also, if you don't want to show any column header then pass the label as blank space.

![table-status-with-color](https://user-images.githubusercontent.com/26645756/37353487-72cbd710-2705-11e8-89b9-7473727f5f7f.png)
