### PR TITLE
Added dashboard for IKE

### DIFF
--- a/public/configurations/dashboards/aarNSG.json
+++ b/public/configurations/dashboards/aarNSG.json
@@ -21,6 +21,10 @@
         {
             "label": "NATT Events",
             "url": "/dashboards/aarNSGNATTEvents"
+        },
+        {
+            "label": "IKE",
+            "url": "/dashboards/aarNSGIKE"
         }
     ],
     "filterOptions": {

--- a/public/configurations/dashboards/aarNSGDetail.json
+++ b/public/configurations/dashboards/aarNSGDetail.json
@@ -24,6 +24,10 @@
         {
             "label": "NATT Events",
             "url": "/dashboards/aarNSGNATTEvents"
+        },
+        {
+            "label": "IKE",
+            "url": "/dashboards/aarNSGIKE"
         }
     ],
     "filterOptions": {

--- a/public/configurations/dashboards/aarNSGIKE.json
+++ b/public/configurations/dashboards/aarNSGIKE.json
@@ -1,12 +1,15 @@
 {
-    "id": "aarNSGNATTEvents",
+    "id": "aarNSGIKE",
     "author": "Bharat Mukheja",
-    "creationDate": "1/19/2018",
-    "title": "AAR NSG ({{snsg}}) NATT Events",
+    "creationDate": "3/6/2018",
+    "title": "AAR NSG ({{snsg}}) IKE",
     "visualizations": [
-        { "id": "aar-nsg-natt-heatmap",             "x": 0, "y": 0,  "w": 12, "h": 15, "minW": 5, "minH": 10, "static": true},
-        { "id": "aar-nsg-natt-details-latest",       "x": 0, "y": 15,  "w": 12, "h": 15, "minW": 5, "minH": 5, "static": true},
-        { "id": "aar-nsg-natt-details-timestamp",       "x": 0, "y": 30,  "w": 12, "h": 15, "minW": 5, "minH": 5, "static": true}
+        { "id": "aar-nsg-ike-tunnel-heatmap",           "x": 0, "y": 0,  "w": 12, "h": 15, "minW": 5, "minH": 10, "static": true},
+        { "id": "aar-nsg-ike-tunnel-traffic-linechart", "x": 0, "y": 15,  "w": 12, "h": 15, "minW": 5, "minH": 5, "static": true},
+        { "id": "aar-nsg-ike-probe-heatmap",            "x": 0, "y": 30,  "w": 12, "h": 15, "minW": 5, "minH": 5, "static": true},
+        { "id": "aar-nsg-ike-probe-detail-table",      "x": 0, "y": 45,  "w": 12, "h": 15, "minW": 5, "minH": 10, "static": true},
+        { "id": "aar-nsg-ike-probe-tier1-detail-table",       "x": 0, "y": 60,  "w": 6, "h": 15, "minW": 5, "minH": 5, "static": true},
+        { "id": "aar-nsg-ike-probe-tier2-detail-table",       "x": 6, "y": 60,  "w": 6, "h": 15, "minW": 5, "minH": 5, "static": true}
     ],
     "links": [
         {
@@ -38,6 +41,7 @@
                     "forceOptions": {
                         "interval": "2m",
                         "prevStartTime": "now-30m",
+                        "aarnsgiketunnelheatmapstartTime":"now-15m",
                         "unit": "m",
                         "duration": "15"
                     }
@@ -48,6 +52,7 @@
                     "forceOptions": {
                         "interval": "2m",
                         "prevStartTime": "now-60m",
+                        "aarnsgiketunnelheatmapstartTime":"now-30m",
                         "unit": "m",
                         "duration": "30"
                     }
@@ -58,6 +63,7 @@
                     "forceOptions": {
                         "interval": "2m",
                         "prevStartTime": "now-120m",
+                        "aarnsgiketunnelheatmapstartTime":"now-60m",
                         "unit": "m",
                         "duration": "60"
                     }

--- a/public/configurations/queries/aar-nsg-ike-probe-detail-table.json
+++ b/public/configurations/queries/aar-nsg-ike-probe-detail-table.json
@@ -1,0 +1,113 @@
+{
+    "id": "aar-nsg-ike-probe-detail-table",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_probestats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": 0,
+            "sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "timestamp": {
+                                            "lte": "{{ike_probe_timestamp}}||+150s",
+                                            "format": "epoch_millis"
+                                        }
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "SourceNSG": "{{snsg}}"
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "TunnelName": "{{tunnel}}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "aggs": {
+                "timestamp": {
+                    "terms": {
+                        "field": "timestamp",
+                        "size":8,
+                         "order" : { "_term" : "desc" }
+                    },
+                    "aggs": {
+                        "TunnelName": {
+                            "terms": {
+                                "field": "TunnelName"
+                            },
+                            "aggs": {
+                                "ProbeName": {
+                                    "terms": {
+                                        "field": "ProbeName"
+                                    },
+                                    "aggs": {
+                                        "ProbeState": {
+                                            "terms": {
+                                                "field": "ProbeState"
+                                            },
+                                            "aggs": {
+                                                "Tier1State": {
+                                                    "terms": {
+                                                        "field": "Tier1State"
+                                                    },
+                                                    "aggs": {
+                                                        "Tier2State": {
+                                                            "terms": {
+                                                                "field": "Tier2State"
+                                                            },
+                                                            "aggs": {
+                                                                "MultipleStatesChanged": {
+                                                                    "terms": {
+                                                                        "script": {
+                                                                            "lang":"painless",
+                                                                            "inline": "doc['MultipleStatesChanged'].value== true? 'true':'false'"
+                                                                      }
+                                                                    },
+                                                                    "aggs": {
+                                                                        "RoundRobinState": {
+                                                                            "terms": {
+                                                                                "field": "RoundRobinState"
+                                                                            }
+                                                                        },
+                                                                             "ProbeFailureReason": {
+                                                                                    "terms": {
+                                                                                        "field": "ProbeFailureReason"
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+

--- a/public/configurations/queries/aar-nsg-ike-probe-heatmap.json
+++ b/public/configurations/queries/aar-nsg-ike-probe-heatmap.json
@@ -1,0 +1,89 @@
+{
+    "id": "aar-nsg-nsg-ike-probe-heatmap",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_probe_status}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size":0,
+		"sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte":"{{startTime:now-15m}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format": "epoch_millis"
+                                }
+                            }
+                        }
+                    ],
+                    "filter": {
+                        "bool":{
+                            "must":[
+                                {
+                                    "term": {
+                                        "SourceNSG":"{{snsg}}"
+                                     }
+                                }                            ]
+                        }
+                    }
+                }
+            },
+"aggs":{
+        "date_histo":{
+            "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "2m"
+                },
+                "aggs":{
+                    "tunnel":{
+                        "terms":{
+                            "field":"TunnelName"
+                        },
+                        "aggs":{
+                            "ProbeState":{
+                                "terms":{
+                                "field":"ProbeState"
+                                },
+                            "aggs":{
+                                "Tier1State":{
+                                    "terms":{
+                                        "field":"Tier1State"
+                                    },
+                                    "aggs":{
+                                        "Tier2State":{
+                                            "terms":{
+                                                "field":"Tier2State"
+                                            },
+                                            "aggs":{
+                                                "ProbeStatus":{
+                                                    "terms": {
+                              "script": {
+                                "lang":"painless",
+                                "inline": "doc['MultipleStatesChanged'].value== true? 'UNSTABLE':doc['ProbeStatus'].value== 'GRAY'? 'STOPPED': doc['ProbeState'].value"
+                              }
+                            }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+}
+}

--- a/public/configurations/queries/aar-nsg-ike-probe-tier-detail-table.json
+++ b/public/configurations/queries/aar-nsg-ike-probe-tier-detail-table.json
@@ -1,0 +1,48 @@
+{
+    "id": "aar-nsg-ike-probe-tier-detail-table",
+    "title": "IKE Tier URL state table",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_probestats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": "1",
+            "sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "timestamp": {
+                                            "lte": "{{ikeProbeDetailTimestamp}}",
+                                            "gte": "{{ikeProbeDetailTimestamp}}",
+                                            "format": "epoch_millis"
+                                        }
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "SourceNSG": "{{snsg}}"
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "TunnelName": "{{tunnel}}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/queries/aar-nsg-ike-probe-tier1-detail-table.json
+++ b/public/configurations/queries/aar-nsg-ike-probe-tier1-detail-table.json
@@ -1,0 +1,48 @@
+{
+    "id": "aar-nsg-ike-probe-tier1-detail-table",
+    "title": "IKE Tier1 URL state table",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_probestats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": "1",
+            "sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "timestamp": {
+                                            "lte": "{{ikeProbeDetailTimestamp}}",
+                                            "gte": "{{ikeProbeDetailTimestamp}}",
+                                            "format": "epoch_millis"
+                                        }
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "SourceNSG": "{{snsg}}"
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "TunnelName": "{{tunnel}}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/queries/aar-nsg-ike-probe-tier2-detail-table.json
+++ b/public/configurations/queries/aar-nsg-ike-probe-tier2-detail-table.json
@@ -1,0 +1,48 @@
+{
+    "id": "aar-nsg-ike-probe-tier2-detail-table",
+    "title": "IKE Tier2 URL state table",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_probestats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": "1",
+            "sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "filter": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "range": {
+                                        "timestamp": {
+                                            "lte": "{{ikeProbeDetailTimestamp}}",
+                                            "gte": "{{ikeProbeDetailTimestamp}}",
+                                            "format": "epoch_millis"
+                                        }
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "SourceNSG": "{{snsg}}"
+                                    }
+                                },
+                                {
+                                    "term": {
+                                        "TunnelName": "{{tunnel}}"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/queries/aar-nsg-ike-tunnel-heatmap.json
+++ b/public/configurations/queries/aar-nsg-ike-tunnel-heatmap.json
@@ -1,0 +1,68 @@
+{
+    "id": "aar-nsg-ike-tunnel-heatmap",
+    "service": "elasticsearch",
+    "query": {
+        "index": "{{index:nuage_ike_stats}}",
+        "type": "{{type:nuage_doc_type}}",
+        "body": {
+            "size": 0,
+            "sort": [
+                {
+                    "timestamp": {
+                        "order": "desc"
+                    }
+                }
+            ],
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "range": {
+                                "timestamp": {
+                                    "gte":"{{startTime:now-15m}}",
+                                    "lte":"{{endTime:now}}",
+                                    "format": "epoch_millis"
+                                }
+                            }
+                        }
+                    ],
+                    "filter": {
+                        "bool":{
+                            "must":[
+                                {
+                                    "term": {
+                                        "SourceNSG":"{{snsg}}"
+                                     }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "aggs": {
+                "date_histo": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "1m"
+                    },
+                    "aggs":{
+                        "tunnel":{
+                            "terms": {
+                                "field": "TunnelName"
+                            },
+                            "aggs":{
+                                "TunnelState": {
+                                    "terms": {
+                                      "script": {
+                                        "inline": "doc['MultipleStatesChanged'].value==true?'UNSTABLE':doc['TunnelState']"
+                                      }
+                                    }
+                                  }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/configurations/queries/aar-nsg-ike-tunnel-traffic-linechart.json
+++ b/public/configurations/queries/aar-nsg-ike-tunnel-traffic-linechart.json
@@ -1,0 +1,63 @@
+{
+    "id":"aar-nsg-ike-tunnel-traffic-linechart",
+    "service":"elasticsearch",
+    "query":{
+        "index":"{{index:nuage_ike_stats}}",
+        "type":"{{type:nuage_doc_type}}",
+        "body":{
+            "sort":{
+              "timestamp":"desc"
+            },
+	    "size":0,
+            "query":{
+                  "bool":{
+                    "must":[
+                        {
+                            "range":{
+                                "timestamp":{
+                                    "gte":"{{aarnsgiketunnelheatmapstartTime:now-15m}}",
+                                    "lte":"{{aarnsgiketunnelheatmapendTime:now}}",
+                                    "format":"epoch_millis"
+                                }
+                            }
+                        },
+                        {
+                            "term": {
+                                "SourceNSG": "{{snsg}}"
+                            }
+                        }
+                    ]
+                }
+            },
+            "aggs":{
+        "date_histo":{
+            "date_histogram": {
+                        "field": "timestamp",
+                        "interval": "1m"
+                },
+                "aggs":{
+                    "tunnel":{
+                        "terms":{
+                            "field":"TunnelName"
+                        },
+                        "aggs":{
+                            "{{ikeTrafficColumn}}":{
+                                "sum":{
+                                    "field":"{{ikeTrafficColumn}}"
+                                    }
+                        },
+                            "throughput":{
+                                "sum":{
+                                    "script":{
+                                        "inline":"doc['{{ikeTrafficColumn}}'].value/60.0"}
+                                    }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+}
+}
+

--- a/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
@@ -3,7 +3,7 @@
     "graph": "Table",
     "title": "Last 8 IKE Probe Status Events",
     "author": "Bharat Mukheja",
-    "description": "Detailed Events table for last 8 events occured on the Probe selected on the heatmap.\n\nFlapping Column = 'true' if probe has gone through multiple state change within 30sec \n\nFor the ProbeStates:\nGREEN => Probe is Up \nRED => Probe is Down \nBLUE => Probe is in HOLD DOWN",
+    "description": "The last 8 events, that occurred during or before the selected time interval in the heatmap, where a probe or probe tier state changed. The timestamp marks the end of the 30 second interval in which this event occurred.\n\nGREEN: Probe is Up\nRED: Probe is Down\nBLUE: Probe is in HOLD DOWN\nFlapping = 'true': the probe has gone through multiple state change within 30 seconds",
     "creationDate": "3/6/2018",
     "data": {
         "searchBar": false,

--- a/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
@@ -1,0 +1,31 @@
+{
+    "id": "aar-nsg-ike-probe-detail-table",
+    "graph": "Table",
+    "title": "Last 8 IKE Probe Status Events",
+    "author": "Bharat Mukheja",
+    "description": "Detailed Events table for last 8 events occured on the Probe selected on the heatmap.\n\nFlapping Column = 'true' if probe has gone through multiple state change within 30sec \n\nFor the ProbeStates:\nGREEN => Probe is Up \nRED => Probe is Down \nBLUE => Probe is in HOLD DOWN",
+    "creationDate": "3/6/2018",
+    "data": {
+        "searchBar": false,
+        "hidePagination":true,
+        "columns": [
+            { "column": "ProbeState","label":"","colors":{"UP":"#7ace4d","DOWN":"#f3264c","UNKNOWN": "white","HOLD_DOWN": "#6b55ed","UNSTABLE": "#ffbb44","STOPPED": "gray"}},
+            { "column": "timestamp","label":"Time","timeFormat": "%b %d, %y %X" },
+            { "column": "TunnelName", "label": "Tunnel Name"},
+            { "column": "ProbeName", "label": "Probe Name"},
+            { "column": "ProbeFailureReason", "label": "Probe Failure Reason"},
+            { "column": "Tier1State","label":"Tier1 State" },
+            { "column": "Tier2State","label":"Tier2 State" },
+            { "column": "RoundRobinState","label":"Round Robin State" },
+            { "column": "MultipleStatesChanged", "label": "Flapping"}
+        ]
+    },
+    "listeners": [
+        {
+            "params": {
+                "ikeProbeDetailTimestamp": "timestamp"
+            }
+        }
+    ],
+    "query": "aar-nsg-ike-probe-detail-table"
+}

--- a/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-detail-table.json
@@ -9,7 +9,7 @@
         "searchBar": false,
         "hidePagination":true,
         "columns": [
-            { "column": "ProbeState","label":"","colors":{"UP":"#7ace4d","DOWN":"#f3264c","UNKNOWN": "white","HOLD_DOWN": "#6b55ed","UNSTABLE": "#ffbb44","STOPPED": "gray"}},
+            { "column": "ProbeState","label":"","colors":{"UP":"green","DOWN":"red","UNKNOWN": "white","HOLD_DOWN": "blue","UNSTABLE": "#faf78e","STOPPED": "gray"}},
             { "column": "timestamp","label":"Time","timeFormat": "%b %d, %y %X" },
             { "column": "TunnelName", "label": "Tunnel Name"},
             { "column": "ProbeName", "label": "Probe Name"},

--- a/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
@@ -1,0 +1,50 @@
+{
+    "id": "aar-nsg-ike-probe-heatmap",
+    "graph": "HeatmapGraph",
+    "title": "Probe Status for all Tunnels on {{snsg}}",
+    "description": "Heatmap showing IKE Probe status history. \n\nGREEN => Probe is Up\nRED => Probe is Down\nGRAY => Probe has stopped\nBLUE => Probe is in HOLD DOWN\nWHITE => There is no data for Probe\nYELLOW => Probe has gone through Multiple State changes.",
+    "author": "Bharat Mukheja",
+    "creationDate": "3/6/2018",
+    "key": "function(d) { return d['tunnel'] + d['date_histo'];}",
+    "data": {
+        "xAlign": true,
+        "xColumn": "date_histo",
+        "xLabel": "Time",
+        "yColumn": "tunnel",
+        "yTickGrid": false,
+        "yLabel": "Tunnel Probes",
+        "legendColumn": "ProbeStatus",
+        "colorColumn": "ProbeStatus",
+        "heatmapColor": {
+            "UP": "#7ace4d",
+            "UNSTABLE": "#ffbb44",
+            "DOWN": "#f3264c",
+            "STOPPED": "#gray",
+            "UNKNOWN": "white",
+            "HOLD_DOWN": "#6b55ed"
+        },
+        "legend": {
+            "show": true,
+            "orientation": "horizontal",
+            "circleSize": 4,
+            "labelOffset": 2
+        },
+        "tooltip": [
+            { "column": "date_histo", "label": "Timestamp", "timeFormat": "%b %d, %y %X"},
+            { "column": "ProbeState", "label": "Probe State" },
+            { "column": "Tier1State", "label": "Tier 1 State" },
+            { "column": "Tier2State", "label": "Tier 2 State" }
+        ]
+   },
+   "listeners": [
+        {
+            "params": {
+                "ike_probe_timestamp": "date_histo",
+                "queryStartTime": "date_histo",
+                "tunnel":"tunnel"
+            }
+        }
+    ],
+    "nextPrevFilter": true,
+    "query": "aar-nsg-ike-probe-heatmap"
+}

--- a/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
@@ -16,12 +16,12 @@
         "legendColumn": "ProbeStatus",
         "colorColumn": "ProbeStatus",
         "heatmapColor": {
-            "UP": "#7ace4d",
-            "UNSTABLE": "#ffbb44",
-            "DOWN": "#f3264c",
-            "STOPPED": "#gray",
+            "UP": "#b3d645",
+            "UNSTABLE": "#faf78e",
+            "DOWN": "#f76159",
+            "STOPPED": "#d9d9d9",
             "UNKNOWN": "white",
-            "HOLD_DOWN": "#6b55ed"
+            "HOLD_DOWN": "lightBlue"
         },
         "legend": {
             "show": true,

--- a/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
@@ -2,7 +2,7 @@
     "id": "aar-nsg-ike-probe-heatmap",
     "graph": "HeatmapGraph",
     "title": "Probe Status for all Tunnels on {{snsg}}",
-    "description": "Heatmap showing IKE Probe status history. \n\nGREEN => Probe is Up\nRED => Probe is Down\nGRAY => Probe has stopped\nBLUE => Probe is in HOLD DOWN\nWHITE => There is no data for Probe\nYELLOW => Probe has gone through Multiple State changes.",
+    "description": "Probe Status Heatmap for all IKE Tunnels sent at 2-minute interval.\n\nGREEN: Probe is UP\nRED: Probe is DOWN\nGRAY: Probe has been stopped because the IKE Tunnel is DOWN\nBLUE: Probe is in HOLD DOWN\nWHITE: There is no data for the probe\nYELLOW: Probe has gone through multiple state changes",
     "author": "Bharat Mukheja",
     "creationDate": "3/6/2018",
     "key": "function(d) { return d['tunnel'] + d['date_histo'];}",

--- a/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-heatmap.json
@@ -12,6 +12,8 @@
         "xLabel": "Time",
         "yColumn": "tunnel",
         "yTickGrid": false,
+        "brush":3,
+        "brushArea":2,
         "yLabel": "Tunnel Probes",
         "legendColumn": "ProbeStatus",
         "colorColumn": "ProbeStatus",

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
@@ -2,7 +2,7 @@
     "id": "aar-nsg-ike-probe-tier1-detail-table",
     "graph": "Table",
     "title": "{{tunnel}} Tier1 URL events at {{ikeProbeDetailTimestamp:call('time_convert')}}",
-    "description":"Table gives IKE Tunnel Tier1 events for the timestamp clicked in Probe Events detail table.\n\nGreen => URL is reachable.\nRed => URL is unreachable\nGray => URL has not been probed in the 30 secs interval",
+    "description":"IKE Tunnel Tier1 events for the timestamp selected in Probe events detail table\n\nGreen: URL is reachable\nRed: URL is unreachable\nGray: URL has not been probed in the 30 secs interval",
     "author": "Bharat Mukheja",
     "creationDate": "3/6/2018",
     "data": {

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
@@ -10,7 +10,7 @@
         "hidePagination":true,
         "columns": [
              { "column": "Tier1URLInfo.UrlString","label":"Tier1 URL String"},
-            { "column": "Tier1URLInfo.UrlState","label":"Tier1 URL State","colors":{"UP":"#7ace4d","DOWN":"#f3264c","NOT_PROBED":"gray"} },
+            { "column": "Tier1URLInfo.UrlState","label":"Tier1 URL State","colors":{"UP":"green","DOWN":"red","NOT_PROBED":"gray"} },
             { "column": "Tier1URLInfo.UrlFailureReason ", "label": "Tier1 Failure Reason (If Any)"}
         ]
     },

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier1-detail-table.json
@@ -1,0 +1,18 @@
+{
+    "id": "aar-nsg-ike-probe-tier1-detail-table",
+    "graph": "Table",
+    "title": "{{tunnel}} Tier1 URL events at {{ikeProbeDetailTimestamp:call('time_convert')}}",
+    "description":"Table gives IKE Tunnel Tier1 events for the timestamp clicked in Probe Events detail table.\n\nGreen => URL is reachable.\nRed => URL is unreachable\nGray => URL has not been probed in the 30 secs interval",
+    "author": "Bharat Mukheja",
+    "creationDate": "3/6/2018",
+    "data": {
+        "searchBar": false,
+        "hidePagination":true,
+        "columns": [
+             { "column": "Tier1URLInfo.UrlString","label":"Tier1 URL String"},
+            { "column": "Tier1URLInfo.UrlState","label":"Tier1 URL State","colors":{"UP":"#7ace4d","DOWN":"#f3264c","NOT_PROBED":"gray"} },
+            { "column": "Tier1URLInfo.UrlFailureReason ", "label": "Tier1 Failure Reason (If Any)"}
+        ]
+    },
+    "query": "aar-nsg-ike-probe-tier1-detail-table"
+}

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
@@ -1,0 +1,18 @@
+{
+    "id": "aar-nsg-ike-probe-tier2-detail-table",
+    "graph": "Table",
+    "title": "{{tunnel}} Tier2 URL events at {{ikeProbeDetailTimestamp:call('time_convert')}}",
+    "description":"Table gives IKE Tunnel Tier2 events for the timestamp clicked in Probe Events detail table.\n\nGreen => URL is reachable.\nRed => URL is unreachable\nGray => URL has not been probed in the 30 secs interval",
+    "author": "Bharat Mukheja",
+    "creationDate": "3/6/2018",
+    "data": {
+        "searchBar": false,
+        "hidePagination":true,
+        "columns": [
+             { "column": "Tier2URLInfo.UrlString","label":"Tier2 URL String"},
+            { "column": "Tier2URLInfo.UrlState","label":"Tier2 URL State","colors":{"UP":"#7ace4d","DOWN":"#f3264c","NOT_PROBED":"gray"} },
+            { "column": "Tier2URLInfo.UrlFailureReason ", "label": "Tier2 Failure Reason (If Any)"}
+        ]
+    },
+    "query": "aar-nsg-ike-probe-tier2-detail-table"
+}

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
@@ -10,7 +10,7 @@
         "hidePagination":true,
         "columns": [
              { "column": "Tier2URLInfo.UrlString","label":"Tier2 URL String"},
-            { "column": "Tier2URLInfo.UrlState","label":"Tier2 URL State","colors":{"UP":"#7ace4d","DOWN":"#f3264c","NOT_PROBED":"gray"} },
+            { "column": "Tier2URLInfo.UrlState","label":"Tier2 URL State","colors":{"UP":"green","DOWN":"red","NOT_PROBED":"gray"} },
             { "column": "Tier2URLInfo.UrlFailureReason ", "label": "Tier2 Failure Reason (If Any)"}
         ]
     },

--- a/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
+++ b/public/configurations/visualizations/aar-nsg-ike-probe-tier2-detail-table.json
@@ -2,7 +2,7 @@
     "id": "aar-nsg-ike-probe-tier2-detail-table",
     "graph": "Table",
     "title": "{{tunnel}} Tier2 URL events at {{ikeProbeDetailTimestamp:call('time_convert')}}",
-    "description":"Table gives IKE Tunnel Tier2 events for the timestamp clicked in Probe Events detail table.\n\nGreen => URL is reachable.\nRed => URL is unreachable\nGray => URL has not been probed in the 30 secs interval",
+    "description":"IKE Tunnel Tier2 events for the timestamp clicked in Probe Events detail table\n\nGreen: URL is reachable\nRed: URL is unreachable\nGray: URL has not been probed in the 30 secs interval",
     "author": "Bharat Mukheja",
     "creationDate": "3/6/2018",
     "data": {

--- a/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
@@ -2,7 +2,7 @@
     "id": "aar-nsg-ike-tunnel-heatmap",
     "graph": "HeatmapGraph",
     "title": "Tunnel Status for all tunnels on {{snsg}}",
-    "description": "Heatmap showing IKE Tunnel status history. \n\nGREEN => Tunnel UP \nRED => Tunnel Down \nYELLOW => Tunnel has gone through multiple state changes",
+    "description": "Heatmap showing IKE Tunnel status\n\nGREEN: Tunnel UP\nRED: Tunnel DOWN\nYELLOW: Tunnel has gone through multiple state changes",
     "author": "Bharat Mukheja",
     "creationDate": "3/6/2018",
     "key": "function(d) { return d['dnsg'] + d['date_histo'];}",

--- a/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
@@ -1,0 +1,46 @@
+{
+    "id": "aar-nsg-ike-tunnel-heatmap",
+    "graph": "HeatmapGraph",
+    "title": "Tunnel Status for all tunnels on {{snsg}}",
+    "description": "Heatmap showing IKE Tunnel status history. \n\nGREEN => Tunnel UP \nRED => Tunnel Down \nYELLOW => Tunnel has gone through multiple state changes",
+    "author": "Bharat Mukheja",
+    "creationDate": "3/6/2018",
+    "key": "function(d) { return d['dnsg'] + d['date_histo'];}",
+    "data": {
+        "xAlign": true,
+        "xColumn": "date_histo",
+        "xLabel": "Time",
+        "yTickGrid": false,
+        "yColumn":"tunnel",
+        "yLabel": "Destination",
+        "legendColumn": "TunnelState",
+        "cellColumn": "TunnelState",
+        "heatmapColor": {
+            "UP": "#7ace4d",
+            "UNSTABLE": "#ffbb44",
+            "DOWN": "#f3264c"
+        },
+        "legend": {
+            "show": true,
+            "orientation": "horizontal",
+            "circleSize": 4,
+            "labelOffset": 2
+        },
+        "tooltip": [
+            { "column": "date_histo", "label": "Timestamp", "timeFormat": "%b %d, %y %X"},
+            { "column": "tunnel", "label": "Tunnel" },
+            { "column": "TunnelState", "label": "Tunnel State" }
+        ]
+   },
+   "listeners": [
+        {
+            "params": {
+                "ike_tunnel_timestamp": "date_histo",
+                "queryStartTime": "date_histo",
+                "tunnel": "tunnel"
+            }
+        }
+    ],
+    "nextPrevFilter": true,
+    "query": "aar-nsg-ike-tunnel-heatmap"
+}

--- a/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
@@ -16,9 +16,9 @@
         "legendColumn": "TunnelState",
         "cellColumn": "TunnelState",
         "heatmapColor": {
-            "UP": "#7ace4d",
-            "UNSTABLE": "#ffbb44",
-            "DOWN": "#f3264c"
+            "UP": "#b3d645",
+            "DOWN": "#f76159",
+            "UNSTABLE":"#faf78e"
         },
         "legend": {
             "show": true,

--- a/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
+++ b/public/configurations/visualizations/aar-nsg-ike-tunnel-heatmap.json
@@ -12,6 +12,8 @@
         "xLabel": "Time",
         "yTickGrid": false,
         "yColumn":"tunnel",
+        "brush":3,
+        "brushArea":2,
         "yLabel": "Destination",
         "legendColumn": "TunnelState",
         "cellColumn": "TunnelState",

--- a/public/configurations/visualizations/aar-nsg-ike-tunnel-traffic-linechart.json
+++ b/public/configurations/visualizations/aar-nsg-ike-tunnel-traffic-linechart.json
@@ -1,0 +1,95 @@
+{
+    "id": "aar-nsg-ike-tunnel-traffic-linechart",
+    "graph": "MultiLineGraph",
+    "title": "Traffic {{ikeTrafficLabel}}",
+    "description": "Line graph displays the traffic and throughput of all tunnel over the selected direction",
+    "author": "Bharat Mukheja",
+    "creationDate": "3/6/2018",
+    "data": {
+        "dateHistogram": true,
+        "xColumn": "date_histo",
+        "yColumn": "{{ikeTrafficColumn}}",
+        "yTickFormat": ".2s",
+        "xLabel": "Time",
+        "yLabel": "{{ikeTrafficLabel}}",
+        "linesColumn": "tunnel",
+        "showNull": false,
+        "legend": {
+            "orientation": "horizontal",
+            "show": true,
+            "circleSize": 5,
+            "labelOffset": 5
+        },
+        "colors": [
+            "#e6194b",
+            "#3cb44b",
+            "#ffe119",
+            "#0082c8",
+            "#f58231",
+            "#911eb4",
+            "#46f0f0",
+            "#f032e6",
+            "#d2f53c",
+            "#fabebe",
+            "#008080",
+            "#e6beff",
+            "#aa6e28",
+            "#fffac8",
+            "#800000",
+            "#aaffc3",
+            "#808000",
+            "#ffd8b1",
+            "#000080",
+            "#808080",
+            "#FFFFFF",
+            "#000000"
+        ],
+        "tooltip": [
+            { "column": "tunnel","label":"Tunnel"},
+            { "column": "yColumn","label":"Total {{ikeTrafficLabel}}","format": ",.2s" },
+            { "column": "throughput","label":"Throughput({{ikeTrafficLabel}}/s)","format": ",.3s" }
+        ]
+    },
+    "query": "aar-nsg-ike-tunnel-traffic-linechart",
+    "filterOptions": {
+        "Traffic Type and Direction": {
+            "parameter": "ikeTrafficType",
+            "default": "TxBytes",
+            "options": [
+                {
+                    "label": "Tx Bytes",
+                    "value": "TxBytes",
+                    "default": true,
+                    "forceOptions": {
+                        "ikeTrafficColumn": "TxBytesCount",
+                        "ikeTrafficLabel": "Bytes"
+                    }
+                },
+                {
+                    "label": "Rx Bytes",
+                    "value": "RxBytes",
+                    "forceOptions": {
+                        "ikeTrafficColumn": "RxBytesCount",
+                        "ikeTrafficLabel": "Bytes"
+                    }
+                },
+                {
+                    "label": "Tx Packets",
+                    "value": "TxPackets",
+                    "forceOptions": {
+                        "ikeTrafficColumn": "TxPacketsCount",
+                        "ikeTrafficLabel": "Packets"
+                    }
+                },
+                {
+                    "label": "Rx Packets",
+                    "value": "RxPackets",
+                    "forceOptions": {
+                        "ikeTrafficColumn": "RxPacketsCount",
+                        "ikeTrafficLabel": "Packets"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/utils/translators/index.js
+++ b/src/utils/translators/index.js
@@ -3,7 +3,7 @@
  */
 
 import demo from './demo'
-import time_convert from './time'
+import time_convert from './time_convert'
 import status from './status'
 
 const translatorList = {

--- a/src/utils/translators/time.js
+++ b/src/utils/translators/time.js
@@ -1,4 +1,0 @@
-export default (value) => {
-    var d = new Date(parseInt(value));
-    return d.toLocaleTimeString();
-}

--- a/src/utils/translators/time_convert.js
+++ b/src/utils/translators/time_convert.js
@@ -1,0 +1,4 @@
+export default (value) => {
+    var d = new Date(parseInt(value));
+    return d.toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true,second:'numeric' });
+}


### PR DESCRIPTION
Added tier1 and tier2 tables


Added description to Tunnel Heatmap


Added First graph

Added tunnel heatmap

Added title to tunnel heatmap


Added traffic linecharts

Added Bytes traffic linechart


Removed all tunnel table


Removed all tunnels list


Fixed title of probe heatmap


Added Probe heatmap


Removed Enterprise Name from ike indexes


Merged and fixed tier tables


Fixed bug


Fixed bug in Ike tunnel heatmap


Fixed probe heatmap click issue


Fixed Probe Heatmap bugs


Modified Probe heatmap


Added throughput to linecharts


Added tunnel detail table


Added Tier1 and Tier2 tables


Merged Bytes and Packets linecharts

Added queries for tier tables


Update aar-nsg-ike-probe-heatmap.json
Changed column name to flapping in probe-detail table

Update aar-nsg-ike-probe-heatmap.json
Update aar-nsg-ike-tunnel-heatmap.json
Fixed Tunnel heatmap for unstable bit

Fixed probestate heatmap bucket

Fixed linechart bug

Fixed bug in probe heatmap name

Update aar-nsg-ike-tunnel-bytes-traffic-linechart.json
Update aar-nsg-ike-tunnel-bytes-traffic-linechart.json
Fixed missing probe detail table probe status bug

Removed tunnel detail table


Added tier tables


Added color to flapping column in probe detail

Added probe detail table


Fixed bug in tunnel detail table


Added click on Probe event details

Fixed bug in probe heatmap


Fixed bytes display in LInecharts


More fixes to names and tier tables

Fixed probe detail table


Fixed probe detail table query


Fixed naming bug


Fixed Heatmap color bug


Testing Tabification


Auto stash before merge of "aar-ike" and "origin/feature/tabify"
http://mvjira.mv.usa.alcatel.com/browse/VSD-24228


Merged Tier tables


Added 30s buffer to probe detail table query


Fixed probe status events table

Aggregated the query to produce single event for a timestamp, thereby removing the tierinfo clutter from the response. Now the tabify can safely table them all in single rows each. This approach also helped in fixing the size where I can fix the number of buckets in terms aggregation
Created separate tables for tier1 and tier2


Corrected comma bug


Fixed comma change


Deleted packet/bytes separate line graphs


JIRA issue http://mvjira.mv.usa.alcatel.com/browse/VSD-24226


Corrected names in Tier table columns


Modification to line chart

JIRA issue http://mvjira.mv.usa.alcatel.com/browse/VSD-24225
Fixed probe heatmap boolean bug


Fixed probe detail boolean bug


Jira issue http://mvjira.mv.usa.alcatel.com/browse/VSD-24227


Added more colors to linechart

Added few 22 fixed colors so that upto 22 tunnels get different colors.
Corrected column names in tier2 url table


Corrected title