### PR TITLE
Fixed-empty data issue #646

### DIFF
--- a/src/components/Graphs/ChordGraph/index.js
+++ b/src/components/Graphs/ChordGraph/index.js
@@ -20,6 +20,10 @@ export default class ChordGraph extends AbstractGraph {
     }
 
     componentDidMount() {
+
+        if(!this.svg)
+          return
+
         this.chordDiagram = ChordDiagram(this.svg);
         this.updateChord(this.props);
 
@@ -81,7 +85,7 @@ export default class ChordGraph extends AbstractGraph {
 
     updateChord(props) {
 
-        const { width, height, onMarkClick } = this.props;
+        const { width, height, onMarkClick } = props;
 
         if(!this.filterData || !this.filterData.length)
           return


### PR DESCRIPTION
@ronakmshah 

Fixed error coming due to empty data. 
The chord diagram is not rendering because of empty data, below is the data where `source` and `destination` fields are null : 

`[  
 {
    "hash": 13007,
    "doc_count": 5760,
    "destination": null,
    "SumOf": 4308566,
    "source": null
  },
  {
    "hash": 10015,
    "doc_count": 5760,
    "destination": null,
    "SumOf": 3599523,
    "source": null
  },
  {
    "hash": 13610,
    "doc_count": 4320,
    "destination": null,
    "SumOf": 3248900,
    "source": null
  },
 .......
]`