### PR TITLE
Align axis marker in a heatmap #651

### DIFF
--- a/public/configurations/visualizations/aar-flow-sla-heatmap.json
+++ b/public/configurations/visualizations/aar-flow-sla-heatmap.json
@@ -7,6 +7,7 @@
     "creationDate": "03/04/2017",
     "key": "function(d) { return d['application'] + d['date_histo'];}",
     "data": {
+        "xAlign": true,
         "xColumn": "date_histo",
         "xLabel": "Time",
         "yColumn": "application",

--- a/src/components/Graphs/HeatmapGraph/index.js
+++ b/src/components/Graphs/HeatmapGraph/index.js
@@ -57,7 +57,8 @@ export default class HeatmapGraph extends XYGraph {
             yTickSizeOuter,
             legendColumn,
             yAxisPadding,
-            emptyBoxColor
+            emptyBoxColor,
+            xAlign
         } = this.getConfiguredProperties();
 
         let nestedXData = dataNest({
@@ -185,8 +186,18 @@ export default class HeatmapGraph extends XYGraph {
         availableHeight = boxSize * distYDatas.length;
         availableWidth  = boxSize * distXDatas.length;
 
+        let minValue = xValues[0]
+        let maxValue = xValues[1]
+
+        if(xAlign) {
+            maxValue += xPadding * 2
+        } else {
+            minValue -= xPadding;
+            maxValue += xPadding;
+        }
+
         const xScale = scaleTime()
-            .domain([xValues[0] - xPadding, xValues[1] + xPadding]);
+            .domain([minValue, maxValue]);
 
         const yScale = scaleBand()
             .domain(distYDatas);
@@ -258,7 +269,7 @@ export default class HeatmapGraph extends XYGraph {
                                 height
                             } = (
                                 {
-                                    x: xScale(d[xColumn]) - boxSize / 2,
+                                    x: xScale(d[xColumn]) - (xAlign ? 0 : boxSize / 2),
                                     y: yScale(d[yColumn]) + yScale.bandwidth() / 2 - boxSize / 2,
                                     width: boxSize,
                                     height: boxSize


### PR DESCRIPTION
@ronakmshah @bmukheja 

The standard way to show markers on axis is in the middle position (center alignment). But as per our requirement I have added both options to show markers from left as well as from the middle position. If you will set `xAlign: true` in settings file then markers will be shown from left position else the default position still same i.e from the middle.
