### PR TITLE
Add option to make secondary queries as an optional query #652

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,17 @@ Here is the list of options:
         data2: "query2"
     }
     ```
-    Note: data key is required in case of object.
+    or
+
+    ```
+    query: {
+        data: "query1",
+        data2: { "name": "query2", "required": false }
+    }
+    ```
+    By default all the queries are mandatory, to make any query (except data query) non-mandatory then set  `"required": false`  in object like above.
+
+    Note: data key is required in case of objec{ "name": "query2", "required": false }t.
 
 - **refreshInterval** set the time interval in `ms` between two refresh. Use `-1` to deactivate refresh.
 - **data** an object that helps you configure your visualization. (See below to find graphs specific data).

--- a/public/configurations/visualizations/example.json
+++ b/public/configurations/visualizations/example.json
@@ -36,6 +36,6 @@
     },
     "query": {
         "data": "vnf-status-linechart",
-        "data2": "vnf-status"
+        "data2": {"name": "vnf-status", "required": false}
     }
 }

--- a/src/components/Graphs/LineGraph/index.js
+++ b/src/components/Graphs/LineGraph/index.js
@@ -248,7 +248,7 @@ class LineGraph extends XYGraph {
 
             if(typeof defaultY === 'object' && defaultY.column) {
                 const dataSource = defaultY.source || 'data'
-                horizontalLineData = this.props[dataSource] ? this.props[dataSource][0] : {}
+                horizontalLineData = this.props[dataSource] && this.props[dataSource].length ? this.props[dataSource][0] : {}
                 defaultYvalue = horizontalLineData[defaultY.column] || null
             }
 

--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -129,7 +129,7 @@ class VisualizationView extends React.Component {
             if (!configuration)
                 return;
 
-            const queryName  = configuration.query,
+            const queries  = configuration.query,
                   scriptName = configuration.script;
 
             if (scriptName) {
@@ -137,16 +137,13 @@ class VisualizationView extends React.Component {
                 executeScriptIfNeeded(scriptName, context);
             }
 
-            if (queryName) {
-
-                const queries =  typeof queryName === 'string' ? {'data' : queryName} : queryName
-
+            if (queries) {
                 for(let query in queries) {
                     if (queries.hasOwnProperty(query)) {
-                        this.props.fetchQueryIfNeeded(queries[query]).then(() => {
+
+                        this.props.fetchQueryIfNeeded(queries[query].name).then(() => {
 
                             const { queryConfigurations, executeQueryIfNeeded, context } = this.props;
-
                             if(!queryConfigurations[query]) {
                                 return
                             }
@@ -285,16 +282,6 @@ class VisualizationView extends React.Component {
             console.log('Main source "data" key is not defined')
             return this.renderCardWithInfo("No data to visualize", "bar-chart");
         }
-
-        for(let source in response) {
-            if(response.hasOwnProperty(source)) {
-                if (!response[source].length) {
-                    console.log(`Source "${source}": No data to visualize`)
-                    return this.renderCardWithInfo("No data to visualize", "bar-chart");
-                }
-            }
-        }
-
 
         let graphHeight = d3.select(`#filter_${id}`).node() ? this.state.height - d3.select(`#filter_${id}`).node().getBoundingClientRect().height : this.state.height;
         return (
@@ -631,14 +618,41 @@ const mapStateToProps = (state, ownProps) => {
     //If configuratrions of visualizations fetched proceed to query configurations
     if (props.configuration && props.configuration.query) {
 
-        const queries =  typeof props.configuration.query === 'string' ? {'data' : props.configuration.query} : props.configuration.query
+         /**
+         * Format the query as given below:
+         * "query": {
+                "data": "query-name-1",
+                "keyName": "query-name-2"
+            }
+        */
+        const queries =  typeof props.configuration.query === 'string' ? {'data' : {'name': props.configuration.query}} : props.configuration.query
+
+        props.configuration.query = {}
 
         //Checking whether all the queries configurations has been fetched
         for(let query in queries) {
             if (queries.hasOwnProperty(query)) {
+
+                /**
+                 * Format the query as given below:
+                 * "query": {
+                        "data": {"name": "query-name-1", "required": true},
+                        "keyName": {"name": "query-name-2", "required": false}
+                    }
+                */
+                let queryConfig = Object.assign({}, typeof queries[query] === 'string' ? { 'name': queries[query]} : queries[query])
+
+                props.configuration.query[query] = queryConfig
+
+                if(query === 'data') {
+                    queryConfig.required = true
+                }
+
+                console.log("zzzzzzzzzzz", props.configuration.query)
+
                 let queryConfiguration = state.configurations.getIn([
                     ConfigurationsActionKeyStore.QUERIES,
-                    queries[query]
+                    queryConfig.name
                 ]);
 
                 if (queryConfiguration && !queryConfiguration.get(
@@ -667,13 +681,13 @@ const mapStateToProps = (state, ownProps) => {
                             requestID
                         ]);
 
-                        if(!response) {
+                        if(!response && queryConfig.required !== false) {
                             props.error = 'Not able to load data'
                         }
 
                         if (response && !response.get(ServiceActionKeyStore.IS_FETCHING)) {
                             let responseJS = response.toJS();
-                            if(responseJS.error) {
+                            if(responseJS.error && queryConfig.required !== false) {
                                 props.error = responseJS.error;
                             } else if(responseJS.results) {
                                 successResultCount++;


### PR DESCRIPTION
@bmukheja  @ronakmshah 

Added an option to make secondary queries as optional queries.
By default, all the queries are mandatory, and if you want to make any query as an optional query then explicitly set flag `required: false` as given below: 


             `"query": {
                       "data": "vnf-status-linechart",
                        "data2": {"name": "vnf-status", "required": false}
             }`

Note: data query always remain mandatory.

The purpose of adding above optional query feature is that earlier if any of the queries has no data due to any reason then graph was not rendered. All the queries were mandatory to show the graph. Now there is a case in geomap where if the second query has no data for connecting markers, then the map should be rendered and if the second query has data then show connection b/w markers.