### PR TITLE
Update config.ini

### DIFF
--- a/src/configs/nuage/scripts/pps-simulator/config.ini
+++ b/src/configs/nuage/scripts/pps-simulator/config.ini
@@ -1,10 +1,12 @@
 [default]
 nsg_count:2
 nsg_prefix:10.20.0.
+nsg_name_prefix:NSG-
 app_count:5
 app_group_count:5
 vport_count:5
 domain_count:1
+domain_name_prefix:L3-
 src_ip_prefix:10.20.30.
 dest_ip_prefix:10.20.30.
 natt_ip_prefix:172.20.30.
@@ -15,3 +17,8 @@ perf_mon_count: 2
 duc_count: 2
 es_server: http://localhost:9200
 es_chunk_size: 500
+out_sla_apps: 2
+[app_list]
+l7class_list: ["HTTP", "SKYPE", "GOOGLE", "NETFLIX", 
+        "CISCOVPN", "MSOffice365", "MSOUTLOOK", "SLIDESHARE", 
+		"FACEBOOK", "WEBEX", "YOUTUBE", "GOOGADS"]


### PR DESCRIPTION
Added values for nsg name, domain name, and app list to match QoL changes made to simulate_pps_stats.py.  Users will now be able to edit these in the config file instead of the script itself.

Honestly can't remember if "out_sla_apps" being added was one of my changes or one of Bharat's that didn't seem to make it into the version I branched from for my edits.
