### PR TITLE
Set page size from table config

### DIFF
--- a/src/configs/nuage/elasticsearch/index.js
+++ b/src/configs/nuage/elasticsearch/index.js
@@ -154,7 +154,7 @@ const getPageSizePath = function() {
 }
 
 const updatePageSize = function(queryConfiguration, pageSize) {
-    objectPath.set(queryConfiguration, this.getSizePath(), pageSize);
+    objectPath.set(queryConfiguration, this.getPageSizePath(), pageSize);
     return queryConfiguration;
 }
 

--- a/src/configs/nuage/vsd/index.js
+++ b/src/configs/nuage/vsd/index.js
@@ -379,7 +379,7 @@ const getPageSizePath = function() {
 }
 
 const updatePageSize = function(queryConfiguration, pageSize) {
-    objectPath.set(queryConfiguration, this.getSizePath(), pageSize);
+    objectPath.set(queryConfiguration, this.getPageSizePath(), pageSize);
     return queryConfiguration;
 }
 

--- a/src/services/servicemanager/redux/actions.js
+++ b/src/services/servicemanager/redux/actions.js
@@ -115,10 +115,11 @@ function fetch(query, context, forceCache, scroll = false, dashboard = null) {
             currentPage = objectPath.get(scrollData, 'currentPage') || 1,
             updatedQuery = { ...query, scroll },
             nextPage = null,
-            pageSize = objectPath.get(updatedQuery, service.getPageSizePath());
+            pageSize = objectPath.get(scrollData, 'pageSize') || config.DATA_PER_PAGE_LIMIT;
 
         if(scroll) {
-            if (!pageSize) {
+            const queryPageSize = objectPath.get(updatedQuery, service.getPageSizePath())
+            if (!queryPageSize) {
                 // Set the size for VSD / ES query for pagination purpose.
                 updatedQuery = service.updatePageSize(updatedQuery, config.DATA_PER_PAGE_LIMIT);
             }
@@ -174,7 +175,6 @@ function fetch(query, context, forceCache, scroll = false, dashboard = null) {
                                 expiration: isElasticService(query.service) ? Date.now() + config.SCROLL_CACHING_QUERY_TIME : null,
                                 event: null,
                                 size: objectPath.get(results.nextQuery, 'length'),
-                                pageSize,
                                 currentPage,
                             }
                         ))


### PR DESCRIPTION
@ronakmshah @natabal @bmukheja 

Set per page size from table configuration instead of ES query in order to optimize performance.
Please have a look.

Respective PR in vis-graph -  https://github.com/nuagenetworks/vis-graphs/pull/19