### PR TITLE
[feature]: add query_source on dropdown filter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -209,7 +209,8 @@ Here is the list of options:
                 {
                     "label": "SYN",
                     "value": "SYN",
-                    "default": true
+                    "default": true,
+                    "query_source": "query-to-execute" // on select this option then query mentioned here will be act as primary query to fetch data for graph. It will replace actual query e.g query.data as mentioned below.
                 },
                 {
                     "label": "SYN-ACK",

--- a/public/database.json
+++ b/public/database.json
@@ -1,6 +1,5 @@
 [
   {
-<<<<<<< HEAD
     "children": null,
     "parentType": null,
     "entityScope": "GLOBAL",
@@ -119,7 +118,7 @@
     "enterpriseID": "61624e2a-c6ae-4346-bc42-cdb22acd6667",
     "NSGVersion": "Nuage NSG 0.0.0_2673",
     "timezoneID": "UTC"
-=======
+  }, {
     "medalType": "Gold",
     "country": "Austria",
     "nbMedals": 2,
@@ -4978,6 +4977,5 @@
     "country": "United States",
     "nbMedals": 29,
     "year": "2012"
->>>>>>> aar-geomap-tomerge
   }
 ]

--- a/src/components/FiltersToolBar/index.js
+++ b/src/components/FiltersToolBar/index.js
@@ -181,7 +181,7 @@ export class FiltersToolBarView extends React.Component {
         };
 
         const sourceQueryId = `${filteredID}query_source`;
-        if ((context[sourceQueryId] && context[sourceQueryId] != sourceQuery) || (!context[sourceQueryId] && sourceQuery)) {
+        if ((context[sourceQueryId] && context[sourceQueryId] !== sourceQuery) || (!context[sourceQueryId] && sourceQuery)) {
             configContexts[sourceQueryId] = sourceQuery
         }
 

--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -607,7 +607,7 @@ class VisualizationView extends React.Component {
 const updateFilterOptions = (state, configurations, context, results = []) => {
 
     if (configurations && configurations.filterOptions) {
-        let filterOptions = Object.assign({}, configurations.filterOptions)
+        let filterOptions = { ...configurations.filterOptions }
         let mainQuery = null;
 
         for (let key in filterOptions) {
@@ -693,7 +693,7 @@ const updateFilterOptions = (state, configurations, context, results = []) => {
         }
 
         return {
-            filterOptions: filterOptions || [],
+            filterOptions,
             mainQuery
         }
     }
@@ -808,9 +808,8 @@ const mapStateToProps = (state, ownProps) => {
         */
         const queries =  typeof props.configuration.query === 'string' ? {'data' : {'name': props.configuration.query}} : props.configuration.query
 
-        const { filterOptions, mainQuery } = updateFilterOptions(state, contextualizeConfiguration, context, props.response);
+        const { filterOptions, mainQuery } = {...updateFilterOptions(state, contextualizeConfiguration, context, props.response)};
         props.filterOptions = filterOptions;
-
         props.configuration.query = {}
 
         //Checking whether all the queries configurations has been fetched

--- a/src/configs/nuage/elasticsearch/tabify.js
+++ b/src/configs/nuage/elasticsearch/tabify.js
@@ -57,7 +57,7 @@ function cartesianProduct(data) {
     for(let i = 0; i < keys.length; i++) {
         if(Array.isArray(data[keys[i]])) {
             if (data[keys[i]].length === 0) {
-                data[keys[i]].push(null);
+                data[keys[i]].push({});
             }
 
             data[keys[i]].forEach(item => {

--- a/src/configs/nuage/elasticsearch/tabify.js
+++ b/src/configs/nuage/elasticsearch/tabify.js
@@ -193,7 +193,7 @@ function flatten(tree, parentNode={}){
 
                         if(value.length) {
                             return value.map(item => {
-                                if (item.key) {
+                                if (item[key]) {
                                     return item;
                                 }
 

--- a/src/configs/nuage/elasticsearch/tabify.js
+++ b/src/configs/nuage/elasticsearch/tabify.js
@@ -56,6 +56,10 @@ function cartesianProduct(data) {
     let keys = Object.keys(data);
     for(let i = 0; i < keys.length; i++) {
         if(Array.isArray(data[keys[i]])) {
+            if (data[keys[i]].length === 0) {
+                data[keys[i]].push(null);
+            }
+
             data[keys[i]].forEach(item => {
                 final.push({...data, [keys[i]]: item})
             });
@@ -188,7 +192,13 @@ function flatten(tree, parentNode={}){
                     if (Array.isArray(value)) {
 
                         if(value.length) {
-                            return value;
+                            return value.map(item => {
+                                if (item.key) {
+                                    return item;
+                                }
+
+                                return {[key]: item};
+                            });
                         }
 
                         node[key] = null;


### PR DESCRIPTION
@ronakmshah @bmukheja 

Added `query_source` option in drop-down filter's options. 
If the option is selected then if it has a property for `query_source` then the query defined in this property 
will override the current main query and data from this query will be passed to render the graph.

Updated the doc as well.

Please note that at a time, we can only use one filter dropdowns to have this options.
