### PR TITLE
Add latest results visualization

### DIFF
--- a/public/configurations/dashboards/infraRegressResults.json
+++ b/public/configurations/dashboards/infraRegressResults.json
@@ -5,9 +5,10 @@
     "title": "Results",
     "visualizations": [
         { "id": "inf-regress-result-major-suites", "x": 0, "y": 0, "w": 3, "h": 20, "minW": 6, "minH": 15, "static": true},
-        { "id": "inf-regress-suites-skipped-perbuild", "x": 3, "y": 0, "w": 9, "h": 20, "minW": 6, "minH": 15, "static": true},
-        { "id": "inf-regress-result-testsuites", "x": 0, "y": 20, "w": 6, "h": 20, "minW": 6, "minH": 15, "static": true},
-        { "id": "inf-regress-result-testcases", "x": 6, "y": 20, "w": 6, "h": 20, "minW": 6, "minH": 15, "static": true}
+        { "id": "inf-regress-results-latest-table", "x": 3, "y": 0, "w": 9, "h": 20, "minW": 6, "minH": 15, "static": true},
+        { "id": "inf-regress-suites-skipped-perbuild", "x": 0, "y": 20, "w": 12, "h": 20, "minW": 6, "minH": 15, "static": true},
+        { "id": "inf-regress-result-testsuites", "x": 0, "y": 40, "w": 6, "h": 20, "minW": 6, "minH": 15, "static": true},
+        { "id": "inf-regress-result-testcases", "x": 6, "y": 40, "w": 6, "h": 20, "minW": 6, "minH": 15, "static": true}
     ],
     "links": [
         {

--- a/public/configurations/queries/inf-regress-results-latest.json
+++ b/public/configurations/queries/inf-regress-results-latest.json
@@ -1,0 +1,66 @@
+{
+  "id": "inf-regress-results-latest",
+  "author": "Ryan Fredette",
+  "service": "elasticsearch",
+  "query": {
+    "index": "nuage_regress",
+    "type": "nuage_doc_type",
+    "body": {
+      "sort": [
+        { "time_regression_started" : {"order" : "desc"}}
+      ],
+      "size": 0,
+      "query": {
+        "bool": {
+          "filter": {
+            "wildcard": { "version.vrs": "{{vrsVersion}}" }
+          },
+          "must_not": {
+            "term": { "result": 0 }
+          }
+        }
+      },
+      "_source": {
+        "excludes": []
+      },
+      "aggs": {
+        "testcase": {
+          "terms": {
+            "field": "testcase",
+            "size": 50,
+            "order": {
+              "_count": "desc"
+            }
+          },
+          "aggs": {
+            "result": {
+              "terms": {
+                "field": "result",
+                "size": 1,
+                "order": {
+                    "latest" : "desc"
+                }
+              },
+              "aggs": {
+                "latest": {
+                    "max": {"field": "time_regression_started"}
+                }
+              }
+            },
+            "secondResult": {
+              "scripted_metric": {
+                "params": {
+                  "_agg": {}
+                },
+                "init_script": "params._agg.myResults = [0, 0]; params._agg.myTimes = [0, 0]",
+                "map_script": "if (doc['time_regression_started'].value > params._agg.myTimes[0]) { params._agg.myResults[1] = params._agg.myResults[0]; params._agg.myTimes[1] = params._agg.myTimes[0]; params._agg.myResults[0] = doc['result'].value; params._agg.myTimes[0] = doc['time_regression_started'].value; } else if (doc['time_regression_started'].value > params._agg.myTimes[1]) { params._agg.myResults[1] = doc['result'].value; params._agg.myTimes[1] = doc['time_regression_started'].value; }",
+                "reduce_script": "long[] results = new long[2]; long[] times = new long[2]; times[0] = times[1] = 0; for (a in params._aggs) { if (a.myTimes[0] > times[0]) { results[1] = results[0]; times[1] = times[0]; results[0] = a.myResults[0]; times[0] = a.myTimes[0]; if (a.myTimes[1] > times[1]) { results[1] = a.myResults[1]; times[1] = a.myTimes[1]; } } else if (a.myTimes[0] > times[1]) { results[1] = a.myResults[0]; times[1] = a.myTimes[0]; } } return results[1];"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/public/configurations/visualizations/inf-regress-results-latest-table.json
+++ b/public/configurations/visualizations/inf-regress-results-latest-table.json
@@ -1,0 +1,28 @@
+{
+    "id": "inf-regress-results-latest-table",
+    "graph": "Table",
+    "title": "Latest Test Results for {{vrsVersion}}",
+    "description": "TBD",
+    "author": "Ryan Fredette",
+    "data": {
+        "columns": [
+            { "column": "testcase", "label": "Test Case"},
+            { "column": "secondResult", "label": "",
+              "colors": {
+                "0": "gray",
+                "1": "red",
+                "2": "green"
+              }
+            },
+            { "column": "result", "label": "",
+              "colors": {
+                "0": "gray",
+                "1": "red",
+                "2": "green"
+              }
+            }
+        ]
+    },
+    "listeners": [],
+    "query": "inf-regress-results-latest"
+}


### PR DESCRIPTION
this visualization lists the two most recent results for each testcase. This can be used to get a basic understanding of how stable a testcase is, or if it's recently passing or failing.