### PR TITLE
Feature/add optional tabify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8015,10 +8015,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
-      "dev": true
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
     },
     "merge-descriptors": {
       "version": "1.0.1",

--- a/src/components/Visualization/index.js
+++ b/src/components/Visualization/index.js
@@ -158,12 +158,17 @@ class VisualizationView extends React.Component {
                                 return
                             }
 
-                            executeQueryIfNeeded(queryConfiguration, context, queries[key].scroll || false, dashboard).then(
-                                () => {
-                                },
-                                (error) => {
-                                }
-                            );
+                            executeQueryIfNeeded(
+                                {...queryConfiguration, tabifyOptions: configuration.data.tabifyOptions || {} },
+                                context,
+                                queries[key].scroll || false,
+                                dashboard)
+                                .then(
+                                    () => {
+                                    },
+                                    (error) => {
+                                    }
+                                );
                         });
                     }
                 }

--- a/src/configs/nuage/elasticsearch/tabify.js
+++ b/src/configs/nuage/elasticsearch/tabify.js
@@ -24,7 +24,7 @@ export default function tabify(response, query = {}) {
     }
 
     // tabify data on the basis of the pre-defined properties in configuration
-    if (query.tabifyOptions) {
+    if (query.tabifyOptions && query.tabifyOptions.join) {
         table = processTabifyOptions(table, query.tabifyOptions);
     }
 
@@ -43,7 +43,7 @@ export default function tabify(response, query = {}) {
     return table;
 }
 
-function processTabifyOptions(table, tabifyOptions = {}) {
+function processTabifyOptions(table, tabifyOptions) {
     const joinFields = tabifyOptions.join;
     return table.map( d => {
         joinFields.forEach(joinField => {


### PR DESCRIPTION
@natabal @bmukheja 

Add custom tabify option to remove duplicate rows in the table.
now the value will be showing comma separated.
Updated docs here - https://github.com/nuagenetworks/vis-graphs/pull/69.
To enable tabifyOptions, we have to add the path of the object of ES response and field name in join array as an object, now it will converting the provided array indexes to comma separated values, instead of generating the multiple rows (avoiding possible duplicates). E.g - 

`

"tabifyOptions": {

    "join": [
        {
            "path": "nuage_metadata.src-pgmem-info",
            "field": "name"
        },
        {
            "path": "nuage_metadata.dst-pgmem-info",
            "field": "name"
        }
    ]
}
`